### PR TITLE
Bug fixes in code for dynamic currents

### DIFF
--- a/source/Waves.cpp
+++ b/source/Waves.cpp
@@ -218,7 +218,7 @@ void Waves::setup(EnvCond *env, const char* folder)
 	if ((env->WaveKin == moordyn::WAVES_NONE) &&
 		(env->Current == moordyn::CURRENTS_NONE))
 	{
-		LOGMSG << "No Waves or Currents, or set externally";
+		LOGMSG << "No Waves or Currents, or set externally\n";
 		return;
 	}
 
@@ -674,7 +674,7 @@ void Waves::setup(EnvCond *env, const char* folder)
 		vector<string> entries = split(lines[4]);
 		const unsigned int nzin = entries.size();
 		for (unsigned int i = 0; i < nzin; i++)
-			UProfileZ[i] = atof(entries[i].c_str());
+			UProfileZ.push_back(atof(entries[i].c_str()));
 
 		// Read the time rows
 		const unsigned int ntin = lines.size() - 6;
@@ -755,6 +755,9 @@ void Waves::setup(EnvCond *env, const char* folder)
 			{
 				for (unsigned int it = 0; it < nt; it++)
 				{
+					// need to set iti, otherwise it will lock to final t after one pass through
+					// initially the upper index we check should always be one timestep ahead of it
+					iti = it + 1;  
 					iti = interp_factor(UProfileT, iti, it * dtWave, ft);
 					ux[0][0][iz][it] = UProfileUx[iz][iti] * ft +
 						UProfileUx[iz][iti - 1] * (1. - ft);
@@ -781,6 +784,7 @@ void Waves::setup(EnvCond *env, const char* folder)
 				unsigned iti = 1;
 				for (unsigned int it = 0; it < nt; it++)
 				{
+					iti = it + 1;  // Set initial iti
 					iti = interp_factor(UProfileT, iti, it * dtWave, ft);
 					for (unsigned int ix = 0; ix < nx; ix++) {
 						for (unsigned int iy = 0; iy < ny; iy++) {


### PR DESCRIPTION
This is a relatively minor PR fixing some bugs in the dynamic currents code.

1. When reading inputs into UProfileZ, I got indexing errors with the old code. Updating to just push the currents to the back of the vector fixed that error.
2. When interpolating currents over the time dimension, the program keeps track of a variable `iti` that indicates the initial "upper index" of interpolation. However, this interpolation is performed at each depth, and if not reset in the inner loop winds up defaulting to the max time after running through all the times once. There may be a better way of fixing this by modifying inter_factor() in misc.h, but for now this appears to fix the bug.