### PR TITLE
Single outfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
-xtnl_MoorDyn_dev
+MoorDyn
 =======
 
 MoorDyn is a lumped-mass mooring dynamics model intended for coupling with floating structure codes. As of 2022 it is available under the BSD 3-Clause license.
 
 More information about MoorDyn is now available at moordyn.readthedocs.io
-
-Note:
-This is a private version of the public Moordyn repo for internal use and modification. As it is a cloned version of the public repo, the branch structure from that repo is intact. As of 6/28/2022, this means that the most up-to-date branch is the branch named __dev__, hence the suffix on the end of this repo-name. In the future, we may merge these changes into main. This note should be changed to reflect that.
-

--- a/compile/DLL/compile64.bat
+++ b/compile/DLL/compile64.bat
@@ -3,7 +3,7 @@ echo on
 rem  temporarily add 64 bit compiler directory to path
 set PATH=C:\mingw64\bin;%PATH%
 
-minGW32-make clean
+rem minGW32-make clean
 
-minGW32-make all
+minGW32-make
 pause

--- a/compile/DLL/compile64.bat
+++ b/compile/DLL/compile64.bat
@@ -3,7 +3,7 @@ echo on
 rem  temporarily add 64 bit compiler directory to path
 set PATH=C:\mingw64\bin;%PATH%
 
-rem minGW32-make clean
+minGW32-make clean
 
-minGW32-make
+minGW32-make all
 pause

--- a/compile/DLL/compile64_debug.bat
+++ b/compile/DLL/compile64_debug.bat
@@ -1,9 +1,0 @@
-echo on
-
-rem  temporarily add 64 bit compiler directory to path
-set PATH=C:\mingw64\bin;%PATH%
-
-rem minGW32-make clean
-
-minGW32-make debug
-@REM pause

--- a/compile/DLL/compile64_debug.bat
+++ b/compile/DLL/compile64_debug.bat
@@ -1,0 +1,9 @@
+echo on
+
+rem  temporarily add 64 bit compiler directory to path
+set PATH=C:\mingw64\bin;%PATH%
+
+rem minGW32-make clean
+
+minGW32-make debug
+@REM pause

--- a/compile/DLL/makefile
+++ b/compile/DLL/makefile
@@ -74,7 +74,7 @@ Misc.o: ../../source/Misc.cpp ../../source/Misc.h ../../source/MoorDynAPI.h
 	$(CXX) $(CPPFLAGS) ../../source/Misc.cpp
 
 clean:
-	$(RM) *.exe.manifest *.exe *.obj *.o *.dll
+	del *.exe.manifest *.exe *.obj *.o *.dll
 
 test_minimal.exe: ../../test/minimal.cpp libmoordyn2.dll ../../source/MoorDyn.h
 	$(CXX) $(EXEFLAGS) -L./ -lmoordyn2 -I../../source/ -o test_minimal.exe ../../test/minimal.cpp

--- a/compile/DLL/makefile
+++ b/compile/DLL/makefile
@@ -88,7 +88,7 @@ test_wavekin.exe: ../../test/wavekin.cpp libmoordyn2.dll ../../source/MoorDyn.h
 test_quasi_static_chain.exe: ../../test/quasi_static_chain.cpp libmoordyn2.dll ../../source/MoorDyn.h
 	$(CXX) $(EXEFLAGS) -L./ -lmoordyn2 -I../../source/ -o test_quasi_static_chain.exe ../../test/quasi_static_chain.cpp
 
-test: test_minimal.exe test_bodies_and_rods.exe test_quasi_static_chain.exe
+test: test_minimal.exe test_bodies_and_rods.exe test_wavekin.exe test_quasi_static_chain.exe
 	./test_minimal.exe
 	./test_bodies_and_rods.exe
 	./test_wavekin.exe
@@ -98,4 +98,10 @@ debug: CFLAGS += -O0 -g -DDEBUG=1
 debug: CPPFLAGS += -O0 -g -DDEBUG=1
 debug: EXEFLAGS += -O0 -g -DDEBUG=1
 
-debug: all test
+debug-test: CFLAGS += -O0 -g -DDEBUG=1
+debug-test: CPPFLAGS += -O0 -g -DDEBUG=1
+debug-test: EXEFLAGS += -O0 -g -DDEBUG=1
+
+debug: all
+
+debug-test: all test

--- a/compile/DLL/makefile
+++ b/compile/DLL/makefile
@@ -74,7 +74,7 @@ Misc.o: ../../source/Misc.cpp ../../source/Misc.h ../../source/MoorDynAPI.h
 	$(CXX) $(CPPFLAGS) ../../source/Misc.cpp
 
 clean:
-	del *.exe.manifest *.exe *.obj *.o *.dll
+	$(RM) *.exe.manifest *.exe *.obj *.o *.dll
 
 test_minimal.exe: ../../test/minimal.cpp libmoordyn2.dll ../../source/MoorDyn.h
 	$(CXX) $(EXEFLAGS) -L./ -lmoordyn2 -I../../source/ -o test_minimal.exe ../../test/minimal.cpp

--- a/source/Line.cpp
+++ b/source/Line.cpp
@@ -162,77 +162,92 @@ void Line::initializeLine(double* X)
 		
 			// output time
 			*outfile << "Time" << "\t ";
+			string name = getLineName();
 			
-			// output positions?
+			// output positions?:w
+
 			//if (find(channels.begin(), channels.end(), "position") != channels.end())
 			if (channels.find("p") != string::npos)
 			{
 				for (int i=0; i<=N; i++)	//loop through nodes
 				{
-					*outfile << "Node" << i << "px \t Node" <<  i << "py \t Node" <<  i << "pz \t ";
+					*outfile << name << "Node" << i << "px \t" 
+					         << name << "Node" <<  i << "py \t"
+							 << name << "Node" <<  i << "pz \t ";
 				}
 			}
 			// output curvatures?
 			if (channels.find("K") != string::npos) {
 				for (int i=0; i<=N; i++)  {
-					*outfile << "Node" << i << "Ku \t ";
+					*outfile << name << "Node" << i << "Ku \t ";
 				}
 			}
 			// output velocities?
 			if (channels.find("v") != string::npos) {
 				for (int i=0; i<=N; i++)  {
-					*outfile << "Node" << i << "vx \t Node" <<  i << "vy \t Node" <<  i << "vz \t ";
+					*outfile << name << "Node" << i << "vx \t" 
+					         << name << "Node" <<  i << "vy \t" 
+							 << name << "Node" <<  i << "vz \t ";
 				}
 			}
 			// output wave velocities?
 			if (channels.find("U") != string::npos) {
 				for (int i=0; i<=N; i++)  {
-					*outfile << "Node" << i << "Ux \t Node" <<  i << "Uy \t Node" <<  i << "Uz \t ";
+					*outfile << name << "Node" << i << "Ux \t" 
+						     << name << "Node" <<  i << "Uy \t" 
+							 << name << "Node" <<  i << "Uz \t ";
 				}
 			}
 			// output hydro force
 			if (channels.find("D") != string::npos) {
 				for (int i=0; i<=N; i++)  {
-					*outfile << "Node" << i << "Dx \t Node" <<  i << "Dy \t Node" <<  i << "Dz \t ";
+					*outfile << name << "Node" << i << "Dx \t" 
+					         << name << "Node" <<  i << "Dy \t" 
+							 << name << "Node" <<  i << "Dz \t ";
 				}
 			}
 			// output internal damping force?
 			if (channels.find("c") != string::npos) {
 				for (int i=1; i<=N; i++)  {
-					*outfile << "Seg" << i << "cx \t Node" <<  i << "cy \t Node" <<  i << "cz \t ";
+					*outfile << name << "Seg" << i << "cx \t" 
+					         << name << "Node" <<  i << "cy \t" 
+							 << name << "Node" <<  i << "cz \t ";
 				}
 			}
 			// output segment tensions?
 			if (channels.find("t") != string::npos) {
 				for (int i=1; i<=N; i++)  {
-					*outfile << "Seg" << i << "Te \t ";
+					*outfile << name << "Seg" << i << "Te \t ";
 				}
 			}			
 			// output segment strains?
 			if (channels.find("s") != string::npos) {
 				for (int i=1; i<=N; i++)  {
-					*outfile << "Seg" << i << "St \t ";
+					*outfile << name << "Seg" << i << "St \t ";
 				}
 			}	
 			// output segment strain rates?
 			if (channels.find("d") != string::npos) {
 				for (int i=1; i<=N; i++)  {
-					*outfile << "Seg" << i << "dSt \t ";
+					*outfile << name << "Seg" << i << "dSt \t ";
 				}
 			}
 			// output seabed contact forces?
 			if (channels.find("b") != string::npos) {
 				for (int i=0; i<=N; i++)  {
-					*outfile << "Node" << i << "bx \t Node" <<  i << "by \t Node" <<  i << "bz \t ";
+					*outfile << name << "Node" << i << "bx \t" 
+					         << name << "Node" <<  i << "by \t" 
+							 << name << "Node" <<  i << "bz \t ";
 				}
 			}
 			
-			*outfile << "\n";   
+			if (env->outputMode != 1)
+				*outfile << "\n";
 			
 			
 			// ----------- write units line ---------------
 
-			if (env->WriteUnits > 0)
+			if (env->WriteUnits > 0 && env->outputMode != 1)  // Don't write units if writing to single file
 			{
 				// output time
 				*outfile << "(s)" << "\t ";
@@ -292,7 +307,8 @@ void Line::initializeLine(double* X)
 						*outfile << "(N) \t";
 				}
 				
-				*outfile << "\n";   // should also write units at some point!
+				if (env->outputMode != 1)
+					*outfile << "\n";   // should also write units at some point!
 			}
 		}
 		else cout << "   Error: unable to write file Line" << number << ".out" << endl;  //TODO: handle this!
@@ -1326,13 +1342,25 @@ void Line::Output(double time)
 				}
 			}
 			
-			*outfile << "\n";
+			if (env->outputMode != 1)
+				*outfile << "\n";
 		}
 		else cout << "Unable to write to output file " << endl;
 	}
 	return;
 };
 
+ofstream* Line::getOutputFilestream()
+{
+	return outfile;
+};
+
+string Line::getLineName()
+{
+	if (env->outputMode == 0)
+		return "";
+	return "Line" + std::to_string(number);
+};
 
 Line::~Line()
 {

--- a/source/Line.h
+++ b/source/Line.h
@@ -153,6 +153,7 @@ public:
 	int getNodePos(int i, double pos[3]);
 	void getNodeCoordinates(double r_out[]);
 	void setNodeWaveKin(double U_in[], double Ud_in[]);
+	std::string getLineName();
 	
 	double GetLineOutput(OutChanProps outChan);
 	
@@ -183,6 +184,8 @@ public:
 	void getEndSegmentInfo(double qEnd[3], double *EIout, double *dlout, int topOfLine);
 	
 	void getStateDeriv(double* Xd, const double dt);
+
+	ofstream* getOutputFilestream();
 	
 	void doRHS( const double* X,  double* Xd, const double time, const double dt);
 

--- a/source/Misc.h
+++ b/source/Misc.h
@@ -671,6 +671,9 @@ typedef struct
 	int writeLog;
 	/// The log file stream
 	ofstream *outfileLogPtr;
+	
+	// should outputting objects write separate outfiles (0) or to one monolithic outfile:
+	int outputMode;
 } EnvCond;
 
 

--- a/source/Misc.h
+++ b/source/Misc.h
@@ -450,7 +450,7 @@ inline unsigned int interp_factor(const vector<T> &xp,
 	}
 
 	// Justto avoid the compiler warnings. This point is actually never reached
-	f = 1.0;
+	f = -1000.0;
 	return xp.size() - 1;
 }
 

--- a/source/MoorDyn2.cpp
+++ b/source/MoorDyn2.cpp
@@ -90,10 +90,10 @@ moordyn::MoorDyn::MoorDyn(const char *infilename)
 		<< "   Copyright: (C) 2021 National Renewable Energy Laboratory, (C) 2014-2019 Matt Hall" << endl
 		<< "   This program is released under the GNU General Public License v3." << endl;
 
-	Cout(MOORDYN_MSG_LEVEL) << "The filename is " << _filepath << endl;
-	Cout(MOORDYN_DBG_LEVEL) << "The basename is " << _basename << endl;
-	Cout(MOORDYN_DBG_LEVEL) << "The basepath is " << _basepath << endl;
-	Cout(MOORDYN_DBG_LEVEL) << "Using RK" << solver << endl;
+	LOGMSG << "The filename is " << _filepath << endl;
+	LOGMSG << "The basename is " << _basename << endl;
+	LOGMSG << "The basepath is " << _basepath << endl;
+	LOGMSG << "Using RK" << solver << endl;
 
 	env.g = 9.8;
 	env.WtrDpth = 0.;

--- a/source/MoorDyn2.cpp
+++ b/source/MoorDyn2.cpp
@@ -301,6 +301,11 @@ moordyn::error_id moordyn::MoorDyn::Init(const double *x, const double *xd)
 	for (unsigned int l = 0; l < LineList.size(); l++)
 		LineList[l]->initializeLine(states + LineStateIs[l]);
 
+	if (env.outputMode == 1)  // Formatting for single-file output headers
+	{
+		ofstream *linesOutputFile = LineList.back()->getOutputFilestream();
+		*linesOutputFile << '\n';
+	}
 	// ------------------ do dynamic relaxation IC gen --------------------
 	
 	LOGMSG << "Finalizing ICs using dynamic relaxation ("
@@ -2238,6 +2243,11 @@ moordyn::error_id moordyn::MoorDyn::AllOutput(double t, double dt)
 		obj->Output(t);
 	for (auto obj : BodyList)
 		obj->Output(t);
+
+	if (env.outputMode == 1) {
+			ofstream* outfile = LineList.back()->getOutputFilestream();
+			*outfile << '\n';
+	}
 
 	return MOORDYN_SUCCESS;
 }

--- a/source/MoorDyn2.cpp
+++ b/source/MoorDyn2.cpp
@@ -108,6 +108,7 @@ moordyn::MoorDyn::MoorDyn(const char *infilename)
 	env.FrictionCoefficient = 0.0;
 	env.FricDamp = 200.0;
 	env.StatDynFricScale = 1.0;
+	env.outputMode = 0;             // by default all objects write to own output files
 
 	const moordyn::error_id err = ReadInFile();
 	MOORDYN_THROW(err, "Exception while reading the input file");
@@ -1629,9 +1630,10 @@ moordyn::error_id moordyn::MoorDyn::ReadInFile()
 					env.FricDamp = atof(entries[0].c_str());
 				else if (name == "StatDynFricScale")
 					env.StatDynFricScale = atof(entries[0].c_str());
-				// output writing period (0 for at every call)
+				else if (name == "outputMode")
+				    env.outputMode = atoi(entries[0].c_str());
 				else if (name == "dtOut")
-					dtOut = atof(entries[0].c_str());
+					dtOut = atof(entries[0].c_str());  // output writing period (0 for at every call)
 				else
 					LOGWRN << "Warning: Unrecognized option '"
 					                        << name << "'" << endl;

--- a/source/Waves.cpp
+++ b/source/Waves.cpp
@@ -678,7 +678,6 @@ void Waves::setup(EnvCond *env, const char* folder)
 		LOGMSG << nzin << '\n';
 		LOGMSG << entries[0] << '\n';
 		for (unsigned int i = 0; i < nzin; i++) {
-			LOGMSG << entries[i].c_str() << '\n';
 			UProfileZ.push_back(atof(entries[i].c_str()));
 		}
 		LOGMSG << "Depths read\n";
@@ -716,10 +715,6 @@ void Waves::setup(EnvCond *env, const char* folder)
 				for (unsigned int iz = 0; iz < nzin; iz++)
 					UProfileUz[iz][it] = 0.0;
 		}
-		
-		std::ostringstream oss;
-		std::copy(UProfileUy[1].begin(), UProfileUy[1].begin()+10, std::ostream_iterator<real>(oss, "\n"));
-		LOGMSG << oss.str() << '\n';
 		LOGMSG << "'" << CurrentsFilename << "' parsed" << endl;
 
 


### PR DESCRIPTION
This PR addresses issue #28 by adding an option that allow the user to have all lines output to a single output file. The user can opt into this behavior by adding `1    outputMode` to the environment setup at the end of their input file. In this mode, all Line objects share a single shared_ptr to one output file. The resultant file is essentially just all the separated output files left-joined on Time. Do note that as it's currently setup, I've dropped the units line. In the future (if we continue to develop this feature) that'll need to be remedied. Also, this currently only works for Lines, but could be reasonably easily expanded to Rods and Bodies.

I'm also including the fixes to Dynamic Currents from #34 here, so we can close that and just merge this if it looks good.

Additionally, I included the RK4 implementation we had been using internally at Kelson before #31 was submitted with a bunch of new solvers. Once #31 is integrated that should be deleted, but for now I included it as it's easy to compile and use with the older system of building. If we'd rather _not_ deal with the bit of added complexity that could add to the ultimate future merge let me know and I will cherry pick those commits out.