### PR TITLE
Drop v2 branch from the nightly packages generation

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ $default-branch, master ]
   pull_request:
-    branches: [ $default-branch, master ]
+    branches: [ $default-branch, master, v2 ]
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -2,9 +2,9 @@ name: CMake
 
 on:
   push:
-    branches: [ $default-branch, master, v2 ]
+    branches: [ $default-branch, master ]
   pull_request:
-    branches: [ $default-branch, master, v2 ]
+    branches: [ $default-branch, master ]
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)


### PR DESCRIPTION
I have no rights to create releases, so I drop v2 from the nightly autogeneration