### PR TITLE
getNonlinearE() shall return E instead of EI when no points

### DIFF
--- a/source/Line.cpp
+++ b/source/Line.cpp
@@ -58,7 +58,7 @@ real
 Line::getNonlinearE(real l_stretched, real l_unstretched)
 {
 	if (!nEApoints)
-		return EI;
+		return E;
 
 	real Xi = l_stretched / l_unstretched - 1.0; // strain rate based on inputs
 	if (Xi < 0.0) {


### PR DESCRIPTION
The typo was actually irrelevant, since on the abscence of points getNonlinearE() is never called