### PR TITLE
Rod dynamics and outputs updates

### DIFF
--- a/source/Body.cpp
+++ b/source/Body.cpp
@@ -307,29 +307,62 @@ Body::setDependentStates()
 real
 Body::GetBodyOutput(OutChanProps outChan)
 {
+
+	vec3 rotations = Quat2Euler(r7.quat);
+
 	if (outChan.QType == PosX)
 		return r7.pos.x();
 	else if (outChan.QType == PosY)
 		return r7.pos.y();
 	else if (outChan.QType == PosZ)
 		return r7.pos.z();
+	else if (outChan.QType == RX)
+		return rotations[0];
+	else if (outChan.QType == RY)
+		return rotations[1];
+	else if (outChan.QType == RZ)
+		return rotations[2];
 	else if (outChan.QType == VelX)
-		return v6[0];
-	else if (outChan.QType == VelY)
-		return v6[1];
-	else if (outChan.QType == VelZ)
-		return v6[2];
-	// else if (outChan.QType == Ten )  return  sqrt(Fnet[0]*Fnet[0] +
-	// Fnet[1]*Fnet[1] + Fnet[2]*Fnet[2]);
-	else if (outChan.QType == FX)
-		return F6net[0]; // added Oct 20
-	else if (outChan.QType == FY)
-		return F6net[1];
-	else if (outChan.QType == FZ)
-		return F6net[2];
-	else {
-		LOGWRN << "Unrecognized output channel " << outChan.QType << endl;
-		return 0.0;
+ 		return v6[0];
+ 	else if (outChan.QType == VelY)
+ 		return v6[1];
+ 	else if (outChan.QType == VelZ)
+ 		return v6[2];
+ 	else if (outChan.QType == RVelX)
+ 		return v6[3]*180.0/pi;
+ 	else if (outChan.QType == RVelY)
+ 		return v6[4]*180.0/pi;
+ 	else if (outChan.QType == RVelZ)
+ 		return v6[5]*180.0/pi;
+ 	else if (outChan.QType == AccX)
+ 		return a6[0];
+ 	else if (outChan.QType == AccY)
+ 		return a6[1];
+ 	else if (outChan.QType == AccZ)
+ 		return a6[2];
+ 	else if (outChan.QType == RAccX)
+ 		return a6[3]*180.0/pi;
+ 	else if (outChan.QType == RAccY)
+ 		return a6[4]*180.0/pi;
+ 	else if (outChan.QType == RAccZ)
+ 		return a6[5]*180.0/pi;
+ 	else if (outChan.QType == Ten)  
+ 		return  sqrt(F6net[0]*F6net[0] + F6net[1]*F6net[1] + F6net[2]*F6net[2]);
+ 	else if (outChan.QType == FX)
+ 		return F6net[0];
+ 	else if (outChan.QType == FY)
+ 		return F6net[1];
+ 	else if (outChan.QType == FZ)
+ 		return F6net[2];
+ 	else if (outChan.QType == MX)
+ 		return F6net[3];
+ 	else if (outChan.QType == MY)
+ 		return F6net[4];
+ 	else if (outChan.QType == MZ)
+ 		return F6net[5];
+ 	else {
+ 		LOGWRN << "Unrecognized output channel " << outChan.QType << endl;
+ 		return 0.0;
 	}
 }
 
@@ -402,15 +435,14 @@ Body::getStateDeriv()
 	doRHS();
 
 	// solve for accelerations in [M]{a}={f}
-	const vec6 acc = solveMat6(M, F6net);
+	a6 = solveMat6(M, F6net);
 
 	// NOTE; is the above still valid even though it includes rotational DOFs?
-	XYZQuat dPos;
 	dPos.pos = v6.head<3>();
 	// this assumes that the angular velocity is about the global coordinates
 	// which is true for bodies
 	dPos.quat = 0.5 * (quaternion(0.0, v6[3], v6[4], v6[5]) * r7.quat).coeffs();
-	return std::make_pair(dPos, acc);
+	return std::make_pair(dPos, a6);
 };
 
 //  this is the big function that calculates the forces on the body

--- a/source/Body.hpp
+++ b/source/Body.hpp
@@ -124,13 +124,17 @@ class Body final : public io::IO
 	// vec6 r6;
 	/// body 6dof velocity[x/y/z]
 	vec6 v6;
+	/// body quaternion position derivative
+	XYZQuat dPos;
+	/// body 6dof acceleration[x/y/z]
+ 	vec6 a6;
 
 	/// fairlead position for coupled bodies [x/y/z]
 	vec6 r_ves;
 	/// fairlead velocity for coupled bodies [x/y/z]
 	vec6 rd_ves;
 
-	/// total force and moment vector on node
+	/// total force and moment vector on body
 	vec6 F6net;
 
 	/// total body mass + added mass matrix including all elements

--- a/source/Connection.cpp
+++ b/source/Connection.cpp
@@ -186,8 +186,14 @@ Connection::GetConnectionOutput(OutChanProps outChan)
 		return rd[1];
 	else if (outChan.QType == VelZ)
 		return rd[2];
-	else if (outChan.QType == Ten)
-		return Fnet.squaredNorm();
+	else if (outChan.QType == AccX)
+ 		return acc[0];
+ 	else if (outChan.QType == AccY)
+ 		return acc[1];
+ 	else if (outChan.QType == AccZ)
+ 		return acc[2];
+ 	else if (outChan.QType == Ten)
+ 		return Fnet.norm();
 	else if (outChan.QType == FX)
 		return Fnet[0]; // added Oct 20
 	else if (outChan.QType == FY)
@@ -299,7 +305,7 @@ Connection::getStateDeriv()
 	doRHS();
 
 	// solve for accelerations in [M]{a}={f}
-	const vec acc = M.inverse() * Fnet;
+	acc = M.inverse() * Fnet;
 
 	// update states
 	return std::make_pair(rd, acc);

--- a/source/Connection.hpp
+++ b/source/Connection.hpp
@@ -145,6 +145,9 @@ class Connection final : public io::IO
 	/// node mass + added mass matrices
 	mat M;
 
+	/// node acceleration
+ 	vec acc; 
+
   public:
 	/** @brief Types of connections
 	 */

--- a/source/Line.cpp
+++ b/source/Line.cpp
@@ -552,6 +552,10 @@ Line::GetLineOutput(OutChanProps outChan)
 		return rd[outChan.NodeID][2];
 	else if (outChan.QType == Ten)
 		return getNodeTen(outChan.NodeID).norm();
+	else if (outChan.QType == TenA)
+ 		return getNodeTen(0).norm();
+ 	else if (outChan.QType == TenB)
+ 		return getNodeTen(N).norm();
 	else if (outChan.QType == FX)
 		return Fnet[outChan.NodeID][0];
 	else if (outChan.QType == FY)

--- a/source/Misc.cpp
+++ b/source/Misc.cpp
@@ -334,9 +334,9 @@ orientationAngles(vec v)
 		throw nan_error("Supplied vector is near zero");
 	real l = v(Eigen::seqN(0, 2)).norm();
 
-	// inclination angle. 0.0 for horizontal vectors (v[2] = 0), growing in
-	// clockwise direction at the XZ plane
-	const real phi = -atan2(v[2], l);
+	// inclination angle. pi/2 for horizontal vectors (v[2] = 0), growing in
+	// counter-clockwise direction at the XZ plane
+	const real phi = atan2(l, v[2]);
 	// heading angle. 0.0 for vectors pointing towards x, growing in
 	// counter-clockwise direction at the XY plane
 	const real beta = (fabs(l) < 1.e-6) ? 0.0 : atan2(v[1], v[0]);

--- a/source/Misc.hpp
+++ b/source/Misc.hpp
@@ -961,6 +961,8 @@ typedef struct _RodProps // (matching Rod Dictionary inputs)
 	double Cat;
 	double Cdn;
 	double Cdt;
+	double CaEnd;
+ 	double CdEnd;
 } RodProps;
 
 typedef struct _ConnectProps // matching node input stuff
@@ -1007,17 +1009,32 @@ enum QTypeEnum : int
 	PosX = 1,
 	PosY = 2,
 	PosZ = 3,
-	VelX = 4,
-	VelY = 5,
-	VelZ = 6,
-	AccX = 7,
-	AccY = 8,
-	AccZ = 9,
-	Ten = 10,
-	FX = 11,
-	FY = 12,
-	FZ = 13
-};
+	RX = 4,
+ 	RY = 5,
+ 	RZ = 6,
+ 	VelX = 7,
+ 	VelY = 8,
+ 	VelZ = 9,
+ 	RVelX = 10,
+ 	RVelY = 11,
+ 	RVelZ = 12,
+ 	AccX = 13,
+ 	AccY = 14,
+ 	AccZ = 15,
+ 	RAccX = 16,
+ 	RAccY = 17,
+ 	RAccZ = 18,
+ 	Ten = 19,
+ 	FX = 20,
+ 	FY = 21,
+ 	FZ = 22,
+ 	MX = 23,
+ 	MY = 24,
+ 	MZ = 25,
+ 	Sub = 26,
+ 	TenA = 27,
+ 	TenB = 28
+ };
 
 // The following are some definitions for use with the output options in
 // MoorDyn. These are for the global output quantities specified by OutList, not
@@ -1046,8 +1063,8 @@ typedef struct _OutChanProps
 	string Name;     // "name of output channel"
 	string Units;    // "units string"
 	QTypeEnum QType; // "type of quantity - 0=tension, 1=x, 2=y, 3=z..."
-	int OType;       // "type of object - 1=line, 2=connect"
-	int NodeID;      // "node number if OType=1.  0=anchor, -1=N=Fairlead"
+	int OType;       // "type of object - 1=line, 2=connect, 3=rod, 4=body"
+ 	int NodeID;      // "node number if OType = 1 or 3. -1 indicated whole rod or fairlead for line"
 	int ObjID; // "number of Connect or Line object", subtract 1 to get the
 	           // index in the LineList or ConnectList
 } OutChanProps;

--- a/source/MoorDyn2.hpp
+++ b/source/MoorDyn2.hpp
@@ -673,6 +673,8 @@ class MoorDyn final : public io::IO
 			    channel);
 		else if (channel.OType == 3)
 			return RodList[channel.ObjID - 1]->GetRodOutput(channel);
+		else if (channel.OType == 4)
+ 			return BodyList[channel.ObjID - 1]->GetBodyOutput(channel);
 		stringstream s;
 		s << "Error: output type of " << channel.Name
 		  << " does not match a supported object type";

--- a/source/Rod.hpp
+++ b/source/Rod.hpp
@@ -123,6 +123,10 @@ class Rod final : public io::IO
 	/// axial drag coefficient [-]
 	/// with respect to surface area, \f$ \pi d l \f$
 	moordyn::real Cdt;
+	// values from input files
+ 	moordyn::real CdEnd;
+ 	// values from input files
+ 	moordyn::real CaEnd;
 
 	/// Rod 6dof position [x,y,z,u1,u2,u3] (end A coordinates and direction unit
 	/// vector)
@@ -131,6 +135,10 @@ class Rod final : public io::IO
 	/// Rod 6dof velocity[vx,vy,vz,wx,wy,wz] (end A velocity and rotational
 	/// velocities about unrotated axes)
 	vec6 v6;
+	/// Final 6dof rod velocity (for output)
+ 	XYZQuat vel7;
+ 	/// Final 6dof rod accelration (for output)
+ 	vec6 acc6;
 
 	// kinematics
 	/// node positions
@@ -182,7 +190,7 @@ class Rod final : public io::IO
 
 	// wave things
 	/// VOF scalar for each segment (1 = fully submerged, 0 = out of water)
-	std::vector<moordyn::real> F;
+	std::vector<moordyn::real> VOF;
 	/// instantaneous axial submerged length [m]
 	real h0;
 
@@ -200,6 +208,8 @@ class Rod final : public io::IO
 	ofstream* outfile;
 	/// A copy of moordyn::MoorDyn::outChans
 	string channels;
+	/// Flag for printing channels and units in rod outfile
+ 	int openedoutfile;
 
 	/** @brief Finds the depth of the water at some (x, y) point. Either using
 	 * env->WtrDpth or the 3D seafloor if available
@@ -316,6 +326,10 @@ class Rod final : public io::IO
 		waves = waves_in;
 		seafloor = seafloor_in;
 	}
+
+	/** @brief Opens rod output file
+ 	*/
+ 	inline void openoutput();
 
 	/** @brief Initialize the rod state
 	 * @return The position and orientation angles (first) and the linear and

--- a/source/Time.cpp
+++ b/source/Time.cpp
@@ -69,10 +69,10 @@ TimeSchemeBase<NSTATE, NDERIV>::Update(real t_local, unsigned int substep)
 	}
 
 	for (unsigned int i = 0; i < rods.size(); i++) {
+		rods[i]->setTime(this->t);
 		if ((rods[i]->type != Rod::PINNED) && (rods[i]->type != Rod::CPLDPIN) &&
 		    (rods[i]->type != Rod::FREE))
 			continue;
-		rods[i]->setTime(this->t);
 		rods[i]->setState(r[substep].rods[i].pos, r[substep].rods[i].vel);
 	}
 


### PR DESCRIPTION
These changes fix a few bugs that existed with rod dynamics, in particular for free rods. The biggest issue was the rod Mass matrix was double counting the node masses. Other issues involved horizontal rods rotating when sinking/falling. They have been verified against MoorDynF and analytical solutions. 

The other set of changes is output flag standardization with MoorDynF. This is in conjunction with an update to MoorDynF that will come soon, and it makes it so both versions accept the same output flags and produce the same output results. Much of it was to bring this version up to date with what the documentation says it can do, and then there are some added features. These changes have also been verified with the changes in MoorDynF for all of the output channels. 