### PR TITLE
Fixed bodies attachments when the body is not on 0,0,0

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,8 +37,9 @@ set(CPP_TESTS
 
 set(CATCH2_TESTS 
     math_tests
-    rods
     testDecomposeString
+    rods
+    minimal_body
 )
 
 function(make_executable test_name)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,7 +22,6 @@ set(TESTS
     beam
     time_schemes
     io
-    rods
     bodies_and_rods
     bodies
     quasi_static_chain
@@ -38,6 +37,7 @@ set(CPP_TESTS
 
 set(CATCH2_TESTS 
     math_tests
+    rods
     testDecomposeString
 )
 
@@ -54,6 +54,7 @@ endfunction()
 
 function(make_catch2_executable test_name)
     make_cpp_executable(${test_name})
+    target_compile_definitions(${test_name} PUBLIC USE_CATCH)
     target_include_directories(${test_name} PUBLIC ${CMAKE_BINARY_DIR}/)
     target_link_libraries(${test_name} PRIVATE Catch2::Catch2WithMain)
 endfunction()

--- a/tests/Mooring/lines_body.txt
+++ b/tests/Mooring/lines_body.txt
@@ -1,0 +1,37 @@
+--------------------- MoorDyn Input File ------------------------------------
+MoorDyn input file of the mooring system for OC3-Hywind
+----------------------- LINE TYPES ------------------------------------------
+TypeName   Diam    Mass/m     EA         BA/-zeta    EI         Cd     Ca     CdAx    CaAx
+(name)     (m)     (kg/m)     (N)        (N-s/-)     (N-m^2)    (-)    (-)    (-)     (-)
+main       0.09    77.7066    384.243E6  -0.8        0          1.6    1.0    0.1     0.0
+---------------------------- BODIES -----------------------------------------------------
+ID   Attachment  X0     Y0    Z0    r0      p0     y0     Mass  CG*      I*       Volume  CdA*   Ca
+(#)  (-)         (m)    (m)   (m)   (deg)   (deg)  (deg)  (kg)  (m)      (kg-m^2) (m^3)   (m^2)  (-)
+1    Coupled     0.0    0.0   -35   0       0      0      0     -35      0        0       0      0
+---------------------- CONNECTION PROPERTIES --------------------------------
+ID    Type      X       Y       Z       Mass   Volume  CdA    Ca
+(#)   (-)       (m)     (m)     (m)     (kg)   (mˆ3)   (m^2)  (-)
+1     Fixed     853.87  0       -320.0  0      0       0      0
+2     Fixed     -426.94 739.47  -320.0  0      0       0      0
+3     Fixed     -426.94 -739.47 -320.0  0      0       0      0
+4     Body1     5.2     0.0     -70.0   0      0       0      0
+5     Body1     -2.6    4.5     -70.0   0      0       0      0
+6     Body1     -2.6    -4.5    -70.0   0      0       0      0
+---------------------- LINES ----------------------------------------
+ID   LineType   AttachA  AttachB  UnstrLen  NumSegs  LineOutputs
+(#)   (name)     (#)      (#)       (m)       (-)     (-)
+1     main       1        4         902.2     20      -
+2     main       2        5         902.2     20      -
+3     main       3        6         902.2     20      -
+---------------------- OPTIONS -----------------------------------------
+2             writeLog      Write a log file
+0.002         dtM           time step to use in mooring integration (s)
+3.0e6         kBot          bottom stiffness (Pa/m)
+3.0e5         cBot          bottom damping (Pa-s/m)
+1025.0        WtrDnsty      water density (kg/m^3)
+320           WtrDpth       water depth (m)
+1.0           dtIC          time interval for analyzing convergence during IC gen (s)
+100.0         TmaxIC        max time for ic gen (s)
+4.0           CdScaleIC     factor by which to scale drag coefficients during dynamic relaxation (-)
+0.001         threshIC      threshold for IC convergence (-)
+------------------------- need this line -------------------------------------- 

--- a/tests/minimal_body.cpp
+++ b/tests/minimal_body.cpp
@@ -156,7 +156,7 @@ TEST_CASE("Minimal body with attached entities")
 	REQUIRE(isclose(x_new[0], VX * dt));
 	REQUIRE(isclose(x_new[1], 0));
 	REQUIRE(isclose(x_new[2], COG_Z));
-	REQUIRE(isclose(x_new[3], 0));
+	REQUIRE(isclose(x_new[3], VRX * dt));
 	REQUIRE(isclose(x_new[4], 0));
 	REQUIRE(isclose(x_new[5], 0));
 	REQUIRE(isclose(dx_new[0], 0));

--- a/tests/minimal_body.cpp
+++ b/tests/minimal_body.cpp
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2022 Jose Luis Cercos-Pita <jlc@core-marine.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/** @file minimal.cpp
+ * Minimal tests that only checks the library is correctly initialized,
+ * running and closing
+ */
+
+#include "MoorDyn.h"
+#include "MoorDyn2.h"
+#include <stdexcept>
+#include <iostream>
+#include <iomanip>
+#include <algorithm>
+#include <cmath>
+#include "util.h"
+
+#define TOL 1.0e-6
+#define COG_Z -35.0
+#define VX 0.01
+#define VRX 0.01 * M_PI / 180.0
+
+using namespace std;
+
+TEST_CASE("Minimal body with attached entities")
+{
+	MoorDyn system = MoorDyn_Create("Mooring/lines_body.txt");
+	REQUIRE(system);
+
+	int err;
+	unsigned int n_dof;
+	err = MoorDyn_NCoupledDOF(system, &n_dof);
+	REQUIRE(err == MOORDYN_SUCCESS);
+	REQUIRE(n_dof == 6);
+
+	double x[6], dx[6];
+	// Get the initial position of the body
+	auto body = MoorDyn_GetBody(system, 1);
+	err = MoorDyn_GetBodyState(body, x, dx);
+	REQUIRE(err == MOORDYN_SUCCESS);
+	REQUIRE(isclose(x[0], 0));
+	REQUIRE(isclose(x[1], 0));
+	REQUIRE(isclose(x[2], COG_Z));
+	REQUIRE(isclose(x[3], 0));
+	REQUIRE(isclose(x[4], 0));
+	REQUIRE(isclose(x[5], 0));
+
+	// Get the initial position of the fairleads
+	double xf_ref[9];
+	for (unsigned int i = 0; i < 3; i++) {
+		auto conn = MoorDyn_GetConnection(system, i + 4);
+		err = MoorDyn_GetConnectPos(conn, xf_ref + 3 * i);
+		REQUIRE(err == MOORDYN_SUCCESS);
+	}
+	err = MoorDyn_Init(system, x, dx);
+	REQUIRE(err == MOORDYN_SUCCESS);
+
+	// Check that the fairleads have not moved
+	double xf[9];
+	for (unsigned int i = 0; i < 3; i++) {
+		auto conn = MoorDyn_GetConnection(system, i + 4);
+		err = MoorDyn_GetConnectPos(conn, xf + 3 * i);
+		REQUIRE(err == MOORDYN_SUCCESS);
+		REQUIRE(isclose(xf[3 * i], xf_ref[3 * i]));
+		REQUIRE(isclose(xf[3 * i + 1], xf_ref[3 * i + 1]));
+		REQUIRE(isclose(xf[3 * i + 2], xf_ref[3 * i + 2]));
+	}
+
+	// Let it run for a little while without moving
+	double f[9];
+	double t = 0.0, dt = 0.5;
+	err = MoorDyn_Step(system, x, dx, f, &t, &dt);
+	REQUIRE(err == MOORDYN_SUCCESS);
+
+	// Check that the fairleads have not moved again
+	for (unsigned int i = 0; i < 3; i++) {
+		auto conn = MoorDyn_GetConnection(system, i + 4);
+		err = MoorDyn_GetConnectPos(conn, xf + 3 * i);
+		REQUIRE(err == MOORDYN_SUCCESS);
+		REQUIRE(isclose(xf[3 * i], xf_ref[3 * i]));
+		REQUIRE(isclose(xf[3 * i + 1], xf_ref[3 * i + 1]));
+		REQUIRE(isclose(xf[3 * i + 2], xf_ref[3 * i + 2]));
+	}
+
+	// Let move it forward a little
+	t += dt;
+	dx[0] = VX;
+	err = MoorDyn_Step(system, x, dx, f, &t, &dt);
+	REQUIRE(err == MOORDYN_SUCCESS);
+
+	// Check the new position and velocity of the body
+	double x_new[6], dx_new[6];
+	err = MoorDyn_GetBodyState(body, x_new, dx_new);
+	REQUIRE(err == MOORDYN_SUCCESS);
+	REQUIRE(isclose(x_new[0], VX * dt));
+	REQUIRE(isclose(x_new[1], 0));
+	REQUIRE(isclose(x_new[2], COG_Z));
+	REQUIRE(isclose(x_new[3], 0));
+	REQUIRE(isclose(x_new[4], 0));
+	REQUIRE(isclose(x_new[5], 0));
+	REQUIRE(isclose(dx_new[0], VX));
+	REQUIRE(isclose(dx_new[1], 0));
+	REQUIRE(isclose(dx_new[2], 0));
+	REQUIRE(isclose(dx_new[3], 0));
+	REQUIRE(isclose(dx_new[4], 0));
+	REQUIRE(isclose(dx_new[5], 0));
+
+	// Check that the fairleads have correctly moved
+	for (unsigned int i = 0; i < 3; i++) {
+		auto conn = MoorDyn_GetConnection(system, i + 4);
+		err = MoorDyn_GetConnectPos(conn, xf + 3 * i);
+		REQUIRE(err == MOORDYN_SUCCESS);
+		REQUIRE(isclose(xf[3 * i], xf_ref[3 * i] + VX * dt));
+		REQUIRE(isclose(xf[3 * i + 1], xf_ref[3 * i + 1]));
+		REQUIRE(isclose(xf[3 * i + 2], xf_ref[3 * i + 2]));
+	}
+
+	// Let rotate it a little
+	t += dt;
+	x[0] = VX * dt;
+	dx[0] = 0.0;
+	dx[3] = VRX;
+	err = MoorDyn_Step(system, x, dx, f, &t, &dt);
+	REQUIRE(err == MOORDYN_SUCCESS);
+
+	// Check the new position and velocity of the body
+	err = MoorDyn_GetBodyState(body, x_new, dx_new);
+	REQUIRE(err == MOORDYN_SUCCESS);
+	REQUIRE(isclose(x_new[0], VX * dt));
+	REQUIRE(isclose(x_new[1], 0));
+	REQUIRE(isclose(x_new[2], COG_Z));
+	REQUIRE(isclose(x_new[3], 0));
+	REQUIRE(isclose(x_new[4], 0));
+	REQUIRE(isclose(x_new[5], 0));
+	REQUIRE(isclose(dx_new[0], 0));
+	REQUIRE(isclose(dx_new[1], 0));
+	REQUIRE(isclose(dx_new[2], 0));
+	REQUIRE(isclose(dx_new[3], VRX));
+	REQUIRE(isclose(dx_new[4], 0));
+	REQUIRE(isclose(dx_new[5], 0));
+
+	// Check that the fairleads have correctly moved
+	for (unsigned int i = 0; i < 3; i++) {
+		auto conn = MoorDyn_GetConnection(system, i + 4);
+		err = MoorDyn_GetConnectPos(conn, xf + 3 * i);
+		REQUIRE(err == MOORDYN_SUCCESS);
+		const double rx = 0.01 * M_PI / 180.0 * dt;
+		const double x_ref = xf_ref[3 * i] + 0.01 * dt;
+		const double y_ref = xf_ref[3 * i + 1] * cos(rx) -
+			(xf_ref[3 * i + 2] - COG_Z) * sin(rx);
+		const double z_ref = xf_ref[3 * i + 1] * sin(rx) +
+			(xf_ref[3 * i + 2] - COG_Z) * cos(rx) + COG_Z;
+		REQUIRE(isclose(xf[3 * i], x_ref));
+		REQUIRE(isclose(xf[3 * i + 1], y_ref));
+		REQUIRE(isclose(xf[3 * i + 2], z_ref));
+	}
+
+	err = MoorDyn_Close(system);
+	REQUIRE(err == MOORDYN_SUCCESS);
+}

--- a/tests/rods.cpp
+++ b/tests/rods.cpp
@@ -47,8 +47,7 @@
 
 using namespace std;
 
-bool
-added_mass()
+TEST_CASE("Added mass")
 {
 	// Do the math for our expected acceleration given the mass and that
 	// Ca = 1.0
@@ -68,54 +67,30 @@ added_mass()
 	cout << endl << " => " << __PRETTY_FUNC_NAME__ << "..." << endl;
 
 	MoorDyn system = MoorDyn_Create("Mooring/rod_tests/AddedMass.txt");
-	if (!system) {
-		cerr << "Failure Creating the Mooring system" << endl;
-		return false;
-	}
+	REQUIRE(system);
 
 	err = MoorDyn_Init(system, NULL, NULL);
-	if (err != MOORDYN_SUCCESS) {
-		cerr << "Failure during the mooring initialization: " << err << endl;
-		return false;
-	}
+	REQUIRE(err == MOORDYN_SUCCESS);
 
 	double t = 0, Tmax = 2.5, dt = 0.1;
 
 	while (t < Tmax) {
 		err = MoorDyn_Step(system, NULL, NULL, NULL, &t, &dt);
-		if (err != MOORDYN_SUCCESS) {
-			cerr << "Failure during the mooring initialization: " << err
-			     << endl;
-			return false;
-		}
+		REQUIRE(err == MOORDYN_SUCCESS);
 
 		const auto rod = MoorDyn_GetRod(system, 1);
 
 		unsigned int n_nodes;
 		err = MoorDyn_GetRodN(rod, &n_nodes);
-		if (err != MOORDYN_SUCCESS) {
-			cerr << "Failure getting the number of nodes for rod " << 1 << ": "
-			     << err << endl;
-			return false;
-		}
+		REQUIRE(err == MOORDYN_SUCCESS);
 
 		double expected_z = -10 + 0.5 * acceleration * t * t;
 		double pos[3];
 		for (unsigned int i = 0; i < n_nodes; i++) {
 
 			err = MoorDyn_GetRodNodePos(rod, i, pos);
-			if (err != MOORDYN_SUCCESS) {
-				cerr << "Failure getting the position of nodes " << i
-				     << " for rod 1"
-				     << ": " << err << endl;
-				return false;
-			}
-			if (!isclose(pos[2], expected_z, 1e-8, 1e-10)) {
-				cerr << "Node " << i << " of Rod 1 should have a z position of "
-				     << expected_z << " but has a z pos of " << pos[2]
-				     << " at t=" << t << endl;
-				return false;
-			}
+			REQUIRE(err == MOORDYN_SUCCESS);
+			REQUIRE(isclose(pos[2], expected_z, 1e-8, 1e-10));
 		}
 		// when the rod get higher than z = -1, stop simulating
 		if (expected_z > -1.0) {
@@ -124,12 +99,7 @@ added_mass()
 	}
 
 	err = MoorDyn_Close(system);
-	if (err != MOORDYN_SUCCESS) {
-		cerr << "Failure closing Moordyn: " << err << endl;
-		return false;
-	}
-
-	return true;
+	REQUIRE(err == MOORDYN_SUCCESS);
 }
 
 /** @brief Pinned rod horizontally lying, which should float towards the
@@ -138,167 +108,74 @@ added_mass()
  * Since there is no damping forces, the rods will be oscillating from one side
  * to the other
  */
-bool
-pinned_floating()
+TEST_CASE("Pinned floating rod")
 {
 	int err;
-	cout << endl << " => " << __PRETTY_FUNC_NAME__ << "..." << endl;
-
 	MoorDyn system = MoorDyn_Create("Mooring/RodPinnedFloating.txt");
-	if (!system) {
-		cerr << "Failure Creating the Mooring system" << endl;
-		return false;
-	}
+	REQUIRE(system);
 
 	err = MoorDyn_Init(system, NULL, NULL);
-	if (err != MOORDYN_SUCCESS) {
-		cerr << "Failure during the mooring initialization: " << err << endl;
-		return false;
-	}
+	REQUIRE(err == MOORDYN_SUCCESS);
 
 	double t = 0, T = 10.0;
 	err = MoorDyn_Step(system, NULL, NULL, NULL, &t, &T);
-	if (err != MOORDYN_SUCCESS) {
-		cerr << "Failure during the mooring initialization: " << err << endl;
-		return false;
-	}
+	REQUIRE(err == MOORDYN_SUCCESS);
 
 	unsigned int n_rods;
 	err = MoorDyn_GetNumberRods(system, &n_rods);
 	for (unsigned int i_rod = 1; i_rod <= n_rods; i_rod++) {
 		const auto rod = MoorDyn_GetRod(system, i_rod);
-		if (!rod) {
-			cerr << "Failure getting the rod " << i_rod << endl;
-			return false;
-		}
+		REQUIRE(rod);
 
 		unsigned int n_nodes;
 		err = MoorDyn_GetRodN(rod, &n_nodes);
-		if (err != MOORDYN_SUCCESS) {
-			cerr << "Failure getting the number of nodes for rod " << i_rod
-			     << ": " << err << endl;
-			return false;
-		}
+		REQUIRE(err == MOORDYN_SUCCESS);
 		// Check that the rod is floating upwards
 		double pos[3];
 		err = MoorDyn_GetRodNodePos(rod, 0, pos);
-		if (err != MOORDYN_SUCCESS) {
-			cerr << "Failure getting first node position for rod " << i_rod
-			     << ": " << err << endl;
-			return false;
-		}
-		cout << pos[0] << ", " << pos[1] << ", " << pos[2] << endl;
+		REQUIRE(err == MOORDYN_SUCCESS);
 		const double z0 = pos[2];
 		err = MoorDyn_GetRodNodePos(rod, n_nodes, pos);
-		if (err != MOORDYN_SUCCESS) {
-			cerr << "Failure getting last node position for rod " << i_rod
-			     << ": " << err << endl;
-			return false;
-		}
+		REQUIRE(err == MOORDYN_SUCCESS);
 		const double z1 = pos[2];
-		cout << pos[0] << ", " << pos[1] << ", " << pos[2] << endl;
-
-		if (z1 < z0) {
-			cerr << "The last node is below the first one for rod " << i_rod
-			     << ": " << z1 << " vs. " << z0 << endl;
-			return false;
-		}
+		REQUIRE(z1 >= z0);
 	}
 
 	err = MoorDyn_Close(system);
-	if (err != MOORDYN_SUCCESS) {
-		cerr << "Failure closing Moordyn: " << err << endl;
-		return false;
-	}
-
-	return true;
+	REQUIRE(err == MOORDYN_SUCCESS);
 }
 
-/** @brief Rod hanging from 2 identical ropes, which should move horizontally
- */
-bool
-hanging()
+TEST_CASE("Hanging rod")
 {
 	int err;
-	cout << endl << " => " << __PRETTY_FUNC_NAME__ << "..." << endl;
-
 	MoorDyn system = MoorDyn_Create("Mooring/RodHanging.txt");
-	if (!system) {
-		cerr << "Failure Creating the Mooring system" << endl;
-		return false;
-	}
+	REQUIRE(system);
 
 	err = MoorDyn_Init(system, NULL, NULL);
-	if (err != MOORDYN_SUCCESS) {
-		cerr << "Failure during the mooring initialization: " << err << endl;
-		return false;
-	}
+	REQUIRE(err == MOORDYN_SUCCESS);
 
 	double t = 0, T = 10.0;
 	err = MoorDyn_Step(system, NULL, NULL, NULL, &t, &T);
-	if (err != MOORDYN_SUCCESS) {
-		cerr << "Failure during the mooring initialization: " << err << endl;
-		return false;
-	}
+	REQUIRE(err == MOORDYN_SUCCESS);
 
 	const auto rod = MoorDyn_GetRod(system, 1);
-	if (!rod) {
-		cerr << "Failure getting the rod" << endl;
-		return false;
-	}
+	REQUIRE(rod);
 
 	unsigned int n_nodes;
 	err = MoorDyn_GetRodN(rod, &n_nodes);
-	if (err != MOORDYN_SUCCESS) {
-		cerr << "Failure getting the number of nodes: " << err << endl;
-		return false;
-	}
+	REQUIRE(err == MOORDYN_SUCCESS);
+
 	// Check that the rod is is not rotating
 	const double l = 20.0;
 	double posa[3], posb[3];
 	err = MoorDyn_GetRodNodePos(rod, 0, posa);
-	if (err != MOORDYN_SUCCESS) {
-		cerr << "Failure getting first node position: " << err << endl;
-		return false;
-	}
-	cout << posa[0] << ", " << posa[1] << ", " << posa[2] << endl;
+	REQUIRE(err == MOORDYN_SUCCESS);
 	err = MoorDyn_GetRodNodePos(rod, n_nodes, posb);
-	if (err != MOORDYN_SUCCESS) {
-		cerr << "Failure getting last node position: " << err << endl;
-		return false;
-	}
-	cout << posb[0] << ", " << posb[1] << ", " << posb[2] << endl;
+	REQUIRE(err == MOORDYN_SUCCESS);
 
-	if (((posa[0] + 0.5 * l) / l > TOL) || ((posb[0] - 0.5 * l) / l > TOL) ||
-	    (fabs(posa[1]) / l > TOL) || (fabs(posb[1]) / l > TOL) ||
-	    (fabs(posa[2] - posb[2]) / l > TOL)) {
-		cerr << "The rod is rotating" << endl;
-		return false;
-	}
+	REQUIRE((posa[0] + 0.5 * l) / l < TOL);
+	REQUIRE((posb[0] - 0.5 * l) / l < TOL);
 
 	err = MoorDyn_Close(system);
-	if (err != MOORDYN_SUCCESS) {
-		cerr << "Failure closing Moordyn: " << err << endl;
-		return false;
-	}
-
-	return true;
-}
-
-/** @brief Runs all the test
- * @return 0 if the tests have ran just fine. The index of the failing test
- * otherwise
- */
-int
-main(int, char**)
-{
-	if (!pinned_floating())
-		return 1;
-	if (!hanging())
-		return 2;
-	if (!added_mass())
-		return 3;
-
-	cout << "rods.cpp passed successfully" << endl;
-	return 0;
+	REQUIRE(err == MOORDYN_SUCCESS);
 }


### PR DESCRIPTION
The whole solver is meant to use global coordinates. Thus, even if we are able to correctly set everything considering body local coordinates it will be prone to errors (time integration, outputs, ...).

I hereby would change the criteria to global coordinates. @mattEhall and @RyanDavies19 do you agree to change it?