### PR TITLE
setup.py deprecated

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -31,14 +31,17 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Create setup.py
-        run: |
-            mv wrappers/python/.github.setup.py setup.py
-            mv wrappers/python/.github.setup.cfg setup.cfg
-        shell: bash
-
       # Used to host cibuildwheel
       - uses: actions/setup-python@v3
+
+      - name: Create setup.py
+        run: |
+            mv wrappers/python/wheels.github/* ./
+            python set_version.py
+            python set_eigen_data.py
+            rm set_version.py set_eigen_data.py
+            
+        shell: bash
 
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.8.1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,13 @@ endif()
 if(${PYTHON_WRAPPER})
     find_package(Python
                  COMPONENTS Interpreter Development REQUIRED)
+    execute_process(COMMAND ${Python_EXECUTABLE} -m build -h
+                    OUTPUT_VARIABLE PYTHON_HAS_BUILD_OUTPUT
+                    RESULT_VARIABLE PYTHON_HAS_BUILD
+                    ERROR_QUIET)
+    if(PYTHON_HAS_BUILD AND NOT PYTHON_HAS_BUILD EQUAL 0)
+        message(FATAL_ERROR "PyPA’s build package is required. Please install it typing '${Python_EXECUTABLE} -m pip install --upgrade build'")
+    endif()
 endif()
 
 if(${RUST_WRAPPER})

--- a/wrappers/python/.github.setup.cfg
+++ b/wrappers/python/.github.setup.cfg
@@ -1,2 +1,0 @@
-[aliases]
-test=pytest 

--- a/wrappers/python/CMakeLists.txt
+++ b/wrappers/python/CMakeLists.txt
@@ -3,6 +3,18 @@ set(PYSRCS "${CMAKE_CURRENT_SOURCE_DIR}/moordyn/__init__.py"
            "${CMAKE_CURRENT_SOURCE_DIR}/cmoordyn.cpp")
 
 # Prepare the install script, injecting some information coming from cMake
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/pyproject.toml.in"
+               "${CMAKE_CURRENT_BINARY_DIR}/tmp/pyproject.toml")
+file(
+    COPY "${CMAKE_CURRENT_BINARY_DIR}/tmp/pyproject.toml"
+    DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
+    FILE_PERMISSIONS OWNER_READ
+                     OWNER_WRITE
+                     OWNER_EXECUTE
+                     GROUP_READ
+                     GROUP_EXECUTE
+                     WORLD_READ
+                     WORLD_EXECUTE)
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/setup.py.in"
                "${CMAKE_CURRENT_BINARY_DIR}/tmp/setup.py")
 file(
@@ -15,15 +27,14 @@ file(
                      GROUP_EXECUTE
                      WORLD_READ
                      WORLD_EXECUTE)
-set(SETUP_PY "${CMAKE_CURRENT_BINARY_DIR}/setup.py")
 
 # Create the target, depending of course on the main library
-set(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/build/moordyn.built")
+set(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/dist/moordyn.built")
 add_custom_command(
     OUTPUT ${OUTPUT}
     COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/cmoordyn.cpp" "${CMAKE_CURRENT_BINARY_DIR}/cmoordyn.cpp"
     COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/moordyn" "${CMAKE_CURRENT_BINARY_DIR}/moordyn"
-    COMMAND ${Python_EXECUTABLE} ${SETUP_PY} build
+    COMMAND ${Python_EXECUTABLE} -m build
     COMMAND ${CMAKE_COMMAND} -E touch ${OUTPUT}
     DEPENDS ${PYSRCS}
 )
@@ -35,6 +46,6 @@ if(${PYTHON_WRAPPER_USERINSTALL})
     set(PY_INSTALL_ARGS "--user")
 endif()
 install(CODE "
-  execute_process(COMMAND ${Python_EXECUTABLE} ${SETUP_PY} install ${PY_INSTALL_ARGS}
+  execute_process(COMMAND ${Python_EXECUTABLE} -m pip install dist/moordyn-${MOORDYN_VERSION}.tar.gz ${PY_INSTALL_ARGS}
                   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 ")

--- a/wrappers/python/pyproject.toml.in
+++ b/wrappers/python/pyproject.toml.in
@@ -23,7 +23,7 @@ classifiers = [
 "Documentation" = "https://moordyn-v2.readthedocs.io" 
 
 [tool.setuptools]
-package-dir = {"" = "./"}
+package-dir = {"" = "."}
 
 [tool.setuptools.packages.find]
-where = ["./"]
+where = ["."]

--- a/wrappers/python/pyproject.toml.in
+++ b/wrappers/python/pyproject.toml.in
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["setuptools>=61.0", "cython"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "moordyn"
+version = "${MOORDYN_VERSION}"
+authors = [
+  { name="Jose Luis Cercos-Pita", email="jlc@core-marine.com" },
+]
+description = "Python wrapper for MoorDyn library"
+readme = "README.md"
+requires-python = ">=3.7"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: BSD-3-Clause",
+    "Operating System :: OS Independent",
+]
+
+[project.urls]
+"Homepage" = "https://github.com/FloatingArrayDesign/MoorDyn"
+"Bug Tracker" = "https://github.com/FloatingArrayDesign/MoorDyn/issues" 
+"Documentation" = "https://moordyn-v2.readthedocs.io" 
+
+[tool.setuptools]
+package-dir = {"" = "./"}
+
+[tool.setuptools.packages.find]
+where = ["./"]

--- a/wrappers/python/setup.py.in
+++ b/wrappers/python/setup.py.in
@@ -35,6 +35,7 @@ import sysconfig
 
 
 def cmakepath(p):
+    
     if sys.platform == "win32":
         return p.replace('/', r'\\')
     return p
@@ -49,15 +50,7 @@ cmoordyn = Extension(
 )
 
 setup(
-    name='moordyn',
-    version='${MOORDYN_VERSION}',
-    package_dir={ '': cmakepath('${CMAKE_CURRENT_BINARY_DIR}') },
-    description='Python wrapper for MoorDyn library',
-    author='Jose Luis Cercos-Pita',
-    author_email='jlc@core-marine.com',
-    ext_modules = [cmoordyn],
     packages=find_packages(include=['moordyn', 'moordyn.*']),
-    install_requires=[],
-    setup_requires=['cython', 'pytest-runner'],
-    tests_require=['pytest'],
+    package_dir={ '': cmakepath('./') },
+    ext_modules = [cmoordyn],
 )

--- a/wrappers/python/wheels.github/pyproject.toml
+++ b/wrappers/python/wheels.github/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 "Documentation" = "https://moordyn-v2.readthedocs.io" 
 
 [tool.setuptools]
-package-dir = {"" = "./"}
+package-dir = {"" = "."}
 
 [tool.setuptools.packages.find]
-where = ["./"]
+where = ["."]

--- a/wrappers/python/wheels.github/pyproject.toml
+++ b/wrappers/python/wheels.github/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["setuptools>=61.0", "cython"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "moordyn"
+version = "${MOORDYN_VERSION}"
+authors = [
+  { name="Jose Luis Cercos-Pita", email="jlc@core-marine.com" },
+]
+description = "Python wrapper for MoorDyn library"
+readme = "README.md"
+requires-python = ">=3.7"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: BSD-3-Clause",
+    "Operating System :: OS Independent",
+]
+
+[project.urls]
+"Homepage" = "https://github.com/FloatingArrayDesign/MoorDyn"
+"Bug Tracker" = "https://github.com/FloatingArrayDesign/MoorDyn/issues" 
+"Documentation" = "https://moordyn-v2.readthedocs.io" 
+
+[tool.setuptools]
+package-dir = {"" = "./"}
+
+[tool.setuptools.packages.find]
+where = ["./"]

--- a/wrappers/python/wheels.github/set_eigen_data.py
+++ b/wrappers/python/wheels.github/set_eigen_data.py
@@ -27,29 +27,20 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
-
-import sys
+# Read the version from the CMakeLists.txt
 import os
-from setuptools import setup, find_packages, Extension
-import sysconfig
 
 
-def cmakepath(p):
-    if sys.platform == "win32":
-        return p.replace('/', r'\\')
-    return p
+eigen_packages = []
+for root, dirs, files in os.walk('source/Eigen'):
+    package = root.replace(os.sep, ".")
+    eigen_packages.append(f'                  "{package}": ["*"],\n')
+eigen_packages = ''.join(eigen_packages).strip()
 
-cmoordyn = Extension(
-    'cmoordyn',
-    sources=[cmakepath('${CMAKE_CURRENT_BINARY_DIR}/cmoordyn.cpp'), ],
-    language='c++',
-    include_dirs=[cmakepath('${CMAKE_SOURCE_DIR}/source'), ],
-    library_dirs=[cmakepath('${CMAKE_BINARY_DIR}/source'), ],
-    extra_link_args=['-lmoordyn', ],
-)
+with open('setup.py', 'r') as f:
+    txt = f.read()
 
-setup(
-    packages=find_packages(include=['moordyn', 'moordyn.*']),
-    package_dir={ '': cmakepath('./') },
-    ext_modules=[cmoordyn],
-)
+txt = txt.replace(r"${EIGEN_PACKAGE_DATA}", eigen_packages)
+
+with open('setup.py', 'w') as f:
+    f.write(txt)

--- a/wrappers/python/wheels.github/set_version.py
+++ b/wrappers/python/wheels.github/set_version.py
@@ -27,29 +27,22 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
+# Read the version from the CMakeLists.txt
+version = ""
+with open('CMakeLists.txt', 'r') as f:
+    txt = f.read()
+    for name in ('MAJOR', 'MINOR', 'PATCH'):
+        prefix = 'set(MOORDYN_{}_VERSION '.format(name)
+        subtxt = txt[txt.find(prefix) + len(prefix):]
+        subtxt = subtxt[:subtxt.find(')\n')]
+        version = version + subtxt + '.'
+    version = version[:-1]
 
-import sys
-import os
-from setuptools import setup, find_packages, Extension
-import sysconfig
 
+with open('pyproject.toml', 'r') as f:
+    txt = f.read()
 
-def cmakepath(p):
-    if sys.platform == "win32":
-        return p.replace('/', r'\\')
-    return p
+txt = txt.replace(r"${MOORDYN_VERSION}", version)
 
-cmoordyn = Extension(
-    'cmoordyn',
-    sources=[cmakepath('${CMAKE_CURRENT_BINARY_DIR}/cmoordyn.cpp'), ],
-    language='c++',
-    include_dirs=[cmakepath('${CMAKE_SOURCE_DIR}/source'), ],
-    library_dirs=[cmakepath('${CMAKE_BINARY_DIR}/source'), ],
-    extra_link_args=['-lmoordyn', ],
-)
-
-setup(
-    packages=find_packages(include=['moordyn', 'moordyn.*']),
-    package_dir={ '': cmakepath('./') },
-    ext_modules=[cmoordyn],
-)
+with open('pyproject.toml', 'w') as f:
+    f.write(txt)

--- a/wrappers/python/wheels.github/setup.py
+++ b/wrappers/python/wheels.github/setup.py
@@ -37,27 +37,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import os
 import shutil
 from setuptools import setup, find_packages, Extension
-import sysconfig
 import platform
 
-
-DESC = """Python version of MoorDyn, a lumped-mass mooring dynamics model
-intended for coupling with floating structure codes.
-
-This is not a wrapper of MoorDyn, but an stand-alone version. Thus you can
-just install and use this package, no need of the MoorDyn library in your
-system.
-
-Please, visit https://moordyn-v2.readthedocs.io to learn more about this package,
-and MoorDyn in general.
-
-If you detect any problem, please feel free to report the issue on the GitHub
-page:
-https://github.com/mattEhall/MoorDyn
-
-WARNING: This is a pre-release version of MoorDyn v2. The API may be changed
-in the future, breaking your program
-"""
 
 # We better copy here the moordyn module
 shutil.rmtree('moordyn', ignore_errors=True)
@@ -81,17 +62,6 @@ MOORDYN_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)),
                             'source')
 MOORDYN_SRCS = get_sources('source')
 MOORDYN_SRCS.append(os.path.join('wrappers', 'python', 'cmoordyn.cpp'))
-
-# Read the version from the CMakeLists.txt
-version = ""
-with open('CMakeLists.txt', 'r') as f:
-    txt = f.read()
-    for name in ('MAJOR', 'MINOR', 'PATCH'):
-        prefix = 'set(MOORDYN_{}_VERSION '.format(name)
-        subtxt = txt[txt.find(prefix) + len(prefix):]
-        subtxt = subtxt[:subtxt.find(')\n')]
-        version = version + subtxt + '.'
-    version = version[:-1]
 
 # Get everything required to compile with VTK support
 vtk_version = '9.2'
@@ -139,16 +109,10 @@ cmoordyn = Extension('cmoordyn',
                      )
 
 setup(
-    name='moordyn',
-    version=version,
-    author='Jose Luis Cercos-Pita',
-    author_email='jlc@core-marine.com',
-    url = 'https://github.com/mattEhall/MoorDyn',
-    description='MoorDyn for Python',
-    long_description = DESC,
-    ext_modules = [cmoordyn],
     packages=find_packages(include=['moordyn', 'moordyn.*']),
-    install_requires=[],
-    setup_requires=['cython', 'pytest-runner'],
-    tests_require=['pytest'],
+    ext_modules=[cmoordyn],
+    package_data={"source": ["*.hpp", "*.h"],
+                  "source.Util": ["*.hpp", "*.h"],
+                  "source.Waves": ["*.hpp", "*.h"],
+                  ${EIGEN_PACKAGE_DATA}}
 )


### PR DESCRIPTION
setup.py based python crafting is finally deprecated, so i moved to pyproyect.toml. It seems to work fine:

https://github.com/core-marine-dev/MoorDyn/actions/runs/5667130409

I am merging right away