### PR TITLE
Body and rod bug fixes

### DIFF
--- a/source/Body.cpp
+++ b/source/Body.cpp
@@ -59,8 +59,10 @@ Body::setup(int number_in,
             vec I_in,
             vec6 CdA_in,
             vec6 Ca_in,
+			EnvCondRef env_in, 
             shared_ptr<ofstream> outfile_pointer)
 {
+	env = env_in;     // set pointer to environment settings object
 	number = number_in;
 	type = type_in;
 	outfile = outfile_pointer.get(); // make outfile point to the right place
@@ -99,7 +101,7 @@ Body::setup(int number_in,
 	M0 = translateMass6(body_rCG, Mtemp);
 
 	// add added mass in each direction about ref point (so only diagonals)
-	M0 += mat6::Identity() * bodyV;
+	M0 += bodyV * bodyCa.asDiagonal() * env->rho_w; // Values are only non-zero if free body
 
 	// --------------- if this is an independent body (not coupled) ----------
 	// set initial position and orientation of body from input file
@@ -226,13 +228,6 @@ Body::initialize()
 
 	return std::make_pair(r7, v6);
 };
-
-void
-Body::setEnv(EnvCondRef env_in, moordyn::WavesRef waves_in)
-{
-	env = env_in;     // set pointer to environment settings object
-	waves = waves_in; // set pointer to Waves  object
-}
 
 void
 Body::setDependentStates()

--- a/source/Body.hpp
+++ b/source/Body.hpp
@@ -200,6 +200,7 @@ class Body final : public io::IO
 	 * @param I Inertia (diagonal matrix components)
 	 * @param CdA Drag coefficient
 	 * @param Ca Added mass coefficient
+	 * @param env_in Global struct that holds environmental settings
 	 * @param outfile The outfile where information shall be witten
 	 */
 	void setup(int number,
@@ -211,6 +212,7 @@ class Body final : public io::IO
 	           vec I,
 	           vec6 CdA,
 	           vec6 Ca,
+			   EnvCondRef env_in,
 	           shared_ptr<ofstream> outfile);
 
 	/** @brief Attach a point to the body
@@ -261,10 +263,13 @@ class Body final : public io::IO
 	void initializeBody(XYZQuat r = XYZQuat::Zero(), vec6 rd = vec6::Zero());
 
 	/** @brief Set the environmental data
-	 * @param env_in Global struct that holds environmental settings
 	 * @param waves_in Global Waves object
 	 */
-	void setEnv(EnvCondRef env_in, moordyn::WavesRef waves_in);
+	inline void setWaves(moordyn::WavesRef waves_in)
+	{
+		waves = waves_in;
+	}
+
 
 	/** @brief set the states (positions and velocities) to all the attached
 	 * entities

--- a/source/Line.cpp
+++ b/source/Line.cpp
@@ -125,9 +125,11 @@ Line::setup(int number_in,
             LineProps* props,
             real UnstrLen_in,
             unsigned int NumSegs,
+			EnvCondRef env_in,
             shared_ptr<ofstream> outfile_pointer,
             string channels_in)
 {
+	env = env_in;     // set pointer to environment settings object
 	number = number_in;
 	// Note, this is a temporary value that will be processed depending on sign
 	// during initializeLine
@@ -219,16 +221,6 @@ Line::setup(int number_in,
 
 	LOGDBG << "   Set up Line " << number << ". " << endl;
 };
-
-void
-Line::setEnv(EnvCondRef env_in,
-             moordyn::WavesRef waves_in,
-             moordyn::SeafloorRef seafloor_in)
-{
-	env = env_in;
-	waves = waves_in;
-	seafloor = seafloor_in;
-}
 
 std::pair<std::vector<vec>, std::vector<vec>>
 Line::initialize()
@@ -613,6 +605,8 @@ Line::calcSubSeg(unsigned int firstNodeIdx,
 		return 1.0; // Both nodes below water; segment must be too
 	} else if (firstNodeZ > 0.0 && secondNodeZ > 0.0) {
 		return 0.0; // Both nodes above water; segment must be too
+	} else if (firstNodeZ == -secondNodeZ) {
+		return 0.5; // Segment halfway submerged
 	} else {
 		// Segment partially submerged - figure out which node is above water
 		vec lowerEnd = firstNodeZ < 0.0 ? r[firstNodeIdx] : r[secondNodeIdx];

--- a/source/Line.hpp
+++ b/source/Line.hpp
@@ -305,6 +305,7 @@ class Line final : public io::IO
 	 * @param props Line properties
 	 * @param l Unstretched line length
 	 * @param n Number of segments
+	 * @param env_in Global struct that holds environmental settings
 	 * @param outfile The outfile where information shall be written
 	 * @param channels The channels/fields that shall be printed in the file
 	 */
@@ -312,17 +313,22 @@ class Line final : public io::IO
 	           LineProps* props,
 	           real l,
 	           unsigned int n,
+			   EnvCondRef env_in,
 	           shared_ptr<ofstream> outfile,
 	           string channels);
 
 	/** @brief Set the environmental data
-	 * @param env_in Global struct that holds environmental settings
 	 * @param waves_in Global Waves object
 	 * @param seafloor_in Global 3D Seafloor object
 	 */
-	void setEnv(EnvCondRef env_in,
-	            moordyn::WavesRef waves_in,
-	            moordyn::SeafloorRef seafloor_in);
+	
+	inline void setWaves(
+				moordyn::WavesRef waves_in,
+				moordyn::SeafloorRef seafloor_in)
+	{
+		waves = waves_in;
+		seafloor = seafloor_in;
+	}
 
 	/** @brief Compute the stationary Initial Condition (IC)
 	 * @param return The states, i.e. the positions of the internal nodes

--- a/source/Misc.cpp
+++ b/source/Misc.cpp
@@ -236,11 +236,11 @@ translateMass(vec r, mat M)
 
 	// product of inertia matrix  [J'] = [m][H] + [J]
 	const mat tempM1 = M * H;
-	Mout.bottomLeftCorner<3, 3>() = tempM1;
-	Mout.topRightCorner<3, 3>() = tempM1.transpose();
+	Mout.topRightCorner<3, 3>() = tempM1;
+	Mout.bottomLeftCorner<3, 3>() = tempM1.transpose();
 
 	// moment of inertia matrix  [I'] = [H][m][H]^T + [J]^T[H] + [H]^T[J] + [I]
-	Mout.bottomRightCorner<3, 3>() = H.transpose() * M * H;
+	Mout.bottomRightCorner<3, 3>() = H * M * H.transpose();
 
 	return Mout;
 }
@@ -255,13 +255,13 @@ translateMass6(vec r, mat6 M)
 	mat6 Mout;
 	const mat m = M.topLeftCorner<3, 3>();
 	Mout.topLeftCorner<3, 3>() = m;
-	const mat J = M.bottomLeftCorner<3, 3>();
+	const mat J = M.topRightCorner<3, 3>();
 	const mat I = M.bottomRightCorner<3, 3>();
 
 	// product of inertia matrix  [J'] = [m][H] + [J]
 	const mat tempM1 = m * H + J;
-	Mout.bottomLeftCorner<3, 3>() = tempM1;
-	Mout.topRightCorner<3, 3>() = tempM1.transpose();
+	Mout.topRightCorner<3, 3>() = tempM1;
+	Mout.bottomLeftCorner<3, 3>() = tempM1.transpose();
 
 	// moment of inertia matrix  [I'] = [H][m][H]^T + [J]^T[H] + [H]^T[J] + [I]
 	const mat tempM2 = H * m * H.transpose(); // [H][m][H]^T

--- a/source/Misc.hpp
+++ b/source/Misc.hpp
@@ -679,9 +679,9 @@ getH(vec r)
 {
 	mat H;
 	// clang-format off
-	H <<   0, -r[2], r[1],
-		r[2],     0, -r[0],
-		-r[1], r[0], 0;
+	H <<   0, r[2], -r[1], 
+		-r[2],     0, r[0],
+		r[1], -r[0], 0;
 	// clang-format on
 	return H;
 }

--- a/source/Point.cpp
+++ b/source/Point.cpp
@@ -62,11 +62,13 @@ Point::setup(int number_in,
                   double V_in,
                   vec F_in,
                   double CdA_in,
-                  double Ca_in)
+                  double Ca_in,
+				  EnvCondRef env_in)
 {
 	// props contains:
-	// Node, Type, X, Y, Z, M, V, FX, FY, FZ, CdA, Ca
+	// Node, Type, X, Y, Z, M, V, FX, FY, FZ, CdA, Ca, env
 
+	env = env_in;     // set pointer to environment settings object
 	number = number_in;
 	type = type_in;
 
@@ -211,16 +213,6 @@ Point::GetPointOutput(OutChanProps outChan)
 	else {
 		return 0.0;
 	}
-}
-
-void
-Point::setEnv(EnvCondRef env_in,
-                   moordyn::WavesRef waves_in,
-                   moordyn::SeafloorRef seafloor_in)
-{
-	env = env_in;     // set pointer to environment settings object
-	waves = waves_in; // set pointer to Waves  object
-	seafloor = seafloor_in;
 }
 
 void

--- a/source/Point.hpp
+++ b/source/Point.hpp
@@ -209,6 +209,7 @@ class Point final : public io::IO
 	 * @param CdA_in Product of drag coefficient and projected area
 	 * @param Ca_in Added mass coefficient used along with V to calculate added
 	 * mass on node
+	 * @param env_in Global struct that holds environmental settings
 	 */
 	void setup(int number_in,
 	           types type_in,
@@ -217,7 +218,8 @@ class Point final : public io::IO
 	           double V_in,
 	           vec F_in,
 	           double CdA_in,
-	           double Ca_in);
+	           double Ca_in,
+			   EnvCondRef env_in);
 
 	/** @brief Attach a line endpoint to this point
 	 * @param theLine The line to be attached
@@ -278,12 +280,16 @@ class Point final : public io::IO
 	real GetPointOutput(OutChanProps outChan);
 
 	/** @brief Set the environmental data
-	 * @param env_in Global struct that holds environmental settings
 	 * @param waves_in Global Waves object
+	 * @param seafloor_in Global 3D Seafloor object
 	 */
-	void setEnv(EnvCondRef env_in,
-	            moordyn::WavesRef waves_in,
-	            moordyn::SeafloorRef seafloor_in);
+	inline void setWaves(
+                   moordyn::WavesRef waves_in,
+                   moordyn::SeafloorRef seafloor_in)
+	{
+		waves = waves_in; // set pointer to Waves  object
+		seafloor = seafloor_in;
+	}
 
 	/** @brief Multiply the drag by a factor
 	 *

--- a/source/Rod.hpp
+++ b/source/Rod.hpp
@@ -286,6 +286,7 @@ class Rod final : public io::IO
 	 * @param props Rod properties
 	 * @param endCoords The coordinates of both end points
 	 * @param n Number of segments
+	 * @param env_in Global struct that holds environmental settings
 	 * @param outfile The outfile where information shall be witten
 	 * @param channels The channels/fields that shall be printed in the file
 	 */
@@ -294,6 +295,7 @@ class Rod final : public io::IO
 	           RodProps* props,
 	           vec6 endCoords,
 	           unsigned int n,
+			   EnvCondRef env_in,
 	           shared_ptr<ofstream> outfile,
 	           string channels);
 
@@ -315,14 +317,12 @@ class Rod final : public io::IO
 	EndPoints removeLine(EndPoints end_point, Line* line);
 
 	/** @brief Set the environmental data
-	 * @param env_in Global struct that holds environmental settings
 	 * @param waves_in Global Waves object
 	 */
-	inline void setEnv(EnvCondRef env_in,
+	inline void setWaves(
 	                   moordyn::WavesRef waves_in,
 	                   moordyn::SeafloorRef seafloor_in)
 	{
-		env = env_in;
 		waves = waves_in;
 		seafloor = seafloor_in;
 	}


### PR DESCRIPTION
Resolves a body added mass bug, a rod Aq bug, rod inertia bug, and a translateMass bug:

The following three bugs have been fixed in the fortran code and are being implemented in a PR soon.

1. The body added mass calculation was adding a volume to the mass, which is dimensionally incorrect, and was missing the water density and the Ca coefficient. To resolve this, the env variable needed to be loaded in the setup function rather than a separate function. To ensure continuity across the objects, I made the setEnv function setWaves (an inline function) and the env variable is now set in the setup function for each object.
2. The rod Aq bug was identified by others at NREL who work on the fortran side. The force labeled Froude-Krylov force is actually the long-wave diffraction force. The force labeled dynamic pressure is actually the Froude Krylov force. The 1 that was added to CaEnd was a mistake because it represents the FK contribution which had already been accounted for in the dynamic pressure calculation (now FK force). See Eq. (32) on page 51 of the HydroDyn manual for the detailed equations: https://www.nrel.gov/wind/nwtc/assets/downloads/HydroDyn/HydroDyn_Manual.pdf 
3. The rod inertia bug has been discussed in #93. The moments of inertia for each rod segment were calculated and summed, however each segment was given the whole rod mass. This has been resolved by dividing the mass by N. See page 4 (non tapered members) for theory: https://openfast.readthedocs.io/en/main/_downloads/39aafbb61663ae16bd1a7e80f305c20b/HydroDyn_Plan_TCF_Morison.docx

The translate mass bug seemed to be introduced in #90. The matrix in the getH function was the transpose of the one in the fortran code. I adjusted the ordering of things in the translate mass function accordingly and v2 cpp now matches the rod dynamics of v2 fortran.   
