### PR TITLE
Bug fix for line fluid inertia forces, and Wavekin 7 Ud_z

### DIFF
--- a/source/Line.cpp
+++ b/source/Line.cpp
@@ -1115,18 +1115,20 @@ Line::getStateDeriv()
 
 		// transverse Froude-Krylov force
 		if (i == 0)
-			Ap[i] = env->rho_w * (1. + Can) * 0.5 * (V[i]) * ap;
+			Ap[i] = env->rho_w * (1. + Can) * 0.5 * (F[i] * V[i]) * ap;
 		else if (i == N)
-			Ap[i] = env->rho_w * (1. + Can) * 0.5 * (V[i - 1]) * ap;
+			Ap[i] = env->rho_w * (1. + Can) * 0.5 * (F[i - 1] * V[i - 1]) * ap;
 		else
-			Ap[i] = env->rho_w * (1. + Can) * 0.5 * (V[i] + V[i - 1]) * ap;
+			Ap[i] = env->rho_w * (1. + Can) * 0.5 *
+			        (F[i] * V[i] + F[i - 1] * V[i - 1]) * ap;
 		// tangential Froude-Krylov force
 		if (i == 0)
-			Aq[i] = env->rho_w * (1. + Cat) * 0.5 * (V[i]) * aq;
+			Aq[i] = env->rho_w * (1. + Cat) * 0.5 * (F[i] * V[i]) * aq;
 		else if (i == N)
-			Aq[i] = env->rho_w * (1. + Cat) * 0.5 * (V[i - 1]) * aq;
+			Aq[i] = env->rho_w * (1. + Cat) * 0.5 * (F[i - 1] * V[i - 1]) * aq;
 		else
-			Aq[i] = env->rho_w * (1. + Cat) * 0.5 * (V[i] + V[i - 1]) * aq;
+			Aq[i] = env->rho_w * (1. + Cat) * 0.5 *
+			        (F[i] * V[i] + F[i - 1] * V[i - 1]) * aq;
 
 		// bottom contact (stiffness and damping, vertical-only for now) -
 		// updated for general case of potentially anchor or fairlead end in

--- a/source/Waves.cpp
+++ b/source/Waves.cpp
@@ -151,18 +151,6 @@ WaveGrid::getWaveKin(const vec3& pos,
 	if (zeta) {
 		*zeta = wave_elev;
 	}
-	if (pos.z() > wave_elev) {
-		if (vel) {
-			*vel = vec::Zero();
-		}
-		if (acc) {
-			*acc = vec::Zero();
-		}
-		if (pdyn) {
-			*pdyn = 0;
-		}
-		return;
-	}
 
 	real stretched_z = 0.0;
 	const real bottom = seafloor.getDepth(vec2(pos.x(), pos.y()));
@@ -171,6 +159,14 @@ WaveGrid::getWaveKin(const vec3& pos,
 	const real avgDepth = seafloor.getAverageDepth();
 
 	stretched_z = (-avgDepth * (pos.z() - bottom)) / actual_depth + avgDepth;
+
+	// If the point is above the water surface, return the values at the water
+	// surface. This is important for situations where a point is out of the
+	// water but the object itself may have significant submergence (sideway
+	// floating line, top node of buoy, etc)
+	if (stretched_z > 0.0) {
+		stretched_z = 0.0;
+	}
 	// LOGMSG << "WaveGrid::getWaveKin - stretched_z = " << stretched_z << endl;
 
 	auto iz = interp_factor(pz, stretched_z, fz);

--- a/source/Waves/SpectrumKin.cpp
+++ b/source/Waves/SpectrumKin.cpp
@@ -57,25 +57,22 @@ SpectrumKin::getWaveKin(vec3 pos,
 	    amplitudes * (omegas * t - kValues * distances + phases).sin();
 	const Eigen::ArrayX<real> cos_waves =
 	    amplitudes * (omegas * t - kValues * distances + phases).cos();
-	const real surface_height = sin_waves.sum();
 
-	if (pos.z() > surface_height) {
-		if (zeta) {
-			*zeta = surface_height;
-		}
-		if (vel) {
-			*vel = vec3::Zero();
-		}
-		if (acc) {
-			*acc = vec3::Zero();
-		}
-		return;
-	}
+	const real surface_height = sin_waves.sum();
 	const real bottom = actualDepth;
 	const real actual_depth = surface_height - bottom;
 
-	const real stretched_z =
+	real stretched_z =
 	    (-avgDepth * (pos.z() - bottom)) / actual_depth + avgDepth;
+
+	// If the point is above the water surface, return the values at the water
+	// surface. This is important for situations where a point is out of the
+	// water but the object itself may have significant submergence (sideway
+	// floating line, top node of buoy, etc)
+	if (stretched_z > 0.0) {
+		stretched_z = 0.0;
+	}
+
 	if (zeta) {
 		*zeta = surface_height;
 	}

--- a/source/Waves/SpectrumKin.cpp
+++ b/source/Waves/SpectrumKin.cpp
@@ -129,7 +129,7 @@ SpectrumKin::getWaveKin(vec3 pos,
 			real a_xy = w * w * cos_waves[I] * COSHNumOvrSIHNDen;
 			real ax = a_xy * betas_x[I];
 			real ay = a_xy * betas_y[I];
-			real az = w * w * sin_waves[I] * SINHNumOvrSIHNDen;
+			real az = -w * w * sin_waves[I] * SINHNumOvrSIHNDen;
 			acc_sum += vec3(ax, ay, az);
 			// TODO Waves - calculate the dynamic pressure (rods use it)
 		}


### PR DESCRIPTION
When lines compute the fluid inertia forces, they didn't include segment submergence in the calculation. It's possible that the code as written expects the volume array to take that into account, which does not currently happen. If you look at the section that computes the mass matrix for each node, it includes a correction for submergence along with the volume array. If we want to rewrite these so that the volume array is actually submerged volume, that's definitely possible. I don't know if there's an advantage one way or the other. 

Additionally in the code for wavekin 7, which sums up component waves at all the nodes, there was a missing minus sign for the z component of the water acceleration. It looks like this issue is specific to this wave mode, it is not present in wave mode 2, which uses the same function to calculate those values as wave mode 3, so those probably both work correctly. 

At some point I'll probably write some water velocity/acceleration unit tests for all the wave modes just to sanity check them, and make it easy to validate any future wave modes.

Update:

I've also gone ahead and fixed a relative minor issue with the wave kinematics (that I introduced along with wave stretching), where previously points out of the water were given zero velocity, and acceleration for their wave kinematics. This can cause issues in situations where a point is near the water surface, and the object itself has some amount of submergence. A good example would be a line modeling some sort of floating hose, what can float with its central axis out of the water. Now, points out of the water get the water kinematics at the waters surface below them, and have to do their own handling of submergence.