### PR TITLE
More Docs Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Further information on MoorDyn can be found on the [documentation site](https://
 
 ## Acknowledgments
 
-Many thanks to all the team of the
 [National Renewable Energy Laboratory (NREL)](https://www.nrel.gov/):
 
   - [Matt Hall](http://matt-hall.ca/moordyn.html)

--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -129,7 +129,7 @@ shown below, and add them to the PATH:
 
 The same holds for CMake:
 
-.. figure:: win_CMake_install.png
+.. figure:: win_cmake_install.png
    :alt: Installing CMake in Windows
 
    Recommended options while installing CMake in Windows
@@ -141,13 +141,11 @@ the following command
 
 .. code-block:: bash
 
-  pacman -S mingw-w64-x86_64-python-setuptools mingw-w64-x86_64-python-pip mingw64/mingw-w64-x86_64-make mingw-w64-x86_64-gcc mingw-w64-x86_64-gdb mingw-w64-x86_64-CMake
+  pacman -S mingw-w64-x86_64-python-setuptools mingw-w64-x86_64-python-pip mingw64/mingw-w64-x86_64-make mingw-w64-x86_64-gcc mingw-w64-x86_64-gdb mingw-w64-x86_64-cmake
 
 Now we need to make the MinGW stack available across the whole system by adding
 it to the PATH environment variable.
-To achieve this, execute "System" from the Windows Init menu, and look for
-"environment".
-Then click on "Edit the system environment variables" and in the
+To achieve this, run "Edit the system environment variables" from the windows start menu and in the
 Window the pops up, click on "Environment Variables..."
 Double click on Path (in the System variables box), and add a new entry:
 "C:\msys64\mingw64\bin"
@@ -176,7 +174,7 @@ We are starting with Eigen3, so in the first box of the window that pops up set
    Cloning Eigen3 repository
 
 Press "Clone" and let Git download the repository.
-Now you can repeat, setting "https://github.com/mattEhall/MoorDyn.git", and
+Now you can repeat, setting "https://github.com/FloatingArrayDesign/MoorDyn.git", and
 "C:\MoorDyn\MoorDyn" to download MoorDyn:
 
 .. figure:: win_git_moordyn.png
@@ -195,7 +193,7 @@ binaries box, and press "Configure".
 The first time you configure a new project, CMake will ask you for the toolchain
 to use. Select "MinGW Makefiles":
 
-.. figure:: win_CMake_selectcompiler.png
+.. figure:: win_cmake_selectcompiler.png
    :alt: Selecting the MinGW generator
 
    Selecting the MinGW toolchain as generator
@@ -210,7 +208,7 @@ as to run the built program through a debugger).
 It is also recommended to disable BUILD_TESTING, EIGEN_BUILD_DOC and
 EIGEN_BUILD_TESTING:
 
-.. figure:: win_CMake_eigen.png
+.. figure:: win_cmake_eigen.png
    :alt: Configuration options for Eigen3
 
    Configuration options for Eigen3
@@ -244,7 +242,7 @@ Select again the "MinGW Makefiles" for the generator.
 When the configuration options appear, set CMAKE_BUILD_TYPE as "Release", and
 enable FORTRAN_WRAPPER and PYTHON_WRAPPER:
 
-.. figure:: win_CMake_moordyn.png
+.. figure:: win_cmake_moordyn.png
    :alt: Configuration options for MoorDyn
 
    Configuration options for MoorDyn
@@ -276,6 +274,16 @@ option and type
   mingw32-make
   cpack -C Release
 
+NOTE: If you are working on a proxy serveryou may need to add the .crt file for your proxy 
+configuration to the folder ``C:/msys64/etc/pki/ca-trust/source/anchors`` or equivalent for your 
+system.
+
+NOTE: You may need to upgrade or install the build tool using pip
+
+.. code-block:: bash
+  
+  \<path-to-python>/python<version>.exe -m pip install --upgrade build
+
 Linux and Mac
 ^^^^^^^^^^^^^
 
@@ -305,7 +313,7 @@ First, download the MoorDyn source code from the repository using git:
 .. code-block:: bash
 
    cd $HOME
-   git clone https://github.com/mattEhall/MoorDyn.git
+   git clone https://github.com/FloatingArrayDesign/MoorDyn.git
    cd MoorDyn
 
 Now, ask CMake to configure everything by typing
@@ -368,4 +376,8 @@ release at https://pypi.org/project/moordyn/. To install, type
 in your system terminal. Pip will take care of everything by you.
 
 **If you want to use the most up to date version of MoorDyn-C as a python module**, follow the 
-instructions in the :ref:`CMake compile section <CMake_compile>`.
+instructions in the :ref:`CMake compile section <CMake_compile>`. Once you have succesfully 
+compiled MoorDyn on your system, change to `MoorDyn/build/wrappers/python/` and execute the 
+following command `python3 setup.py install`. This will build the python module locally from 
+the source code you have installed. In order to update this module in the future you will need 
+to update your local source code and follow the same steps above.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,8 +32,9 @@ else:
     subprocess.call('doxygen', shell=True)
 os.makedirs("_build/doxygen/out", exist_ok=True)
 if os.path.exists('_build/doxygen/out/doxygen/html'):
-    os.remove('_build/doxygen/out/doxygen/html')
+    os.system('rm -r _build/doxygen/out/doxygen/html')
 shutil.rmtree('_build/doxygen/html', '_build/doxygen/out/doxygen')
+# shutil.move('_build/doxygen/html', '_build/doxygen/out/doxygen')
 
 breathe_projects['MoorDyn'] = "_build/doxygen/xml"
 breathe_default_project = "MoorDyn"

--- a/docs/drivers.rst
+++ b/docs/drivers.rst
@@ -22,10 +22,10 @@ MoorDyn to be run simultaneously, while MoorDyn-F v2 and MoorDyn-C/F v1 only all
 instance at a time. Any driver function will call at least the following MoorDyn 
 functions:
 
- - Create (MoorDyn-C v2 only)
- - Initialize
- - Step
- - Close
+* Create (MoorDyn-C v2 only)
+* Initialize
+* Step
+* Close
 
 The initialize function takes the state vectors at time 0 and sets up MoorDyn for a time 
 series simulation. It will also find the steady state of the system if the input file 
@@ -55,6 +55,8 @@ Driving MoorDyn-C v1 is a similar process as MoorDyn v2. MoorDyn-C v1 has no bui
 couplings and needs to be driven based on the C API in the MoorDyn.h file. An example on 
 how to do this in python is provided at the end of the 
 :ref:`python section <python_wrapper>`.
+
+Note: the dt value that you give to the step function needs to be the same value that you specify as dtM in the input file. 
 
 MoorDyn-C Coupling
 ------------------
@@ -370,7 +372,7 @@ this time developed in C:
 
 In the example above everything starts calling
 
-.. doxygenfunction:: MoorDyn_Create()
+.. doxygenfunction:: MoorDyn_Create
 
 and checking that it returned a non-NULL system. A NULL system would mean that
 there were an error building up the system. You can learn more about the
@@ -388,8 +390,8 @@ The next step is initializing the system, which computes the
 static solution if the TmaxIC flag in the options section is greater than 0. This 
 requires the position of the coupled fairleads.
 
-.. doxygenfunction:: MoorDyn_GetPoint()
-.. doxygenfunction:: MoorDyn_GetPointPos()
+.. doxygenfunction:: MoorDyn_GetPoint
+.. doxygenfunction:: MoorDyn_GetPointPos
 
 The :ref:`C API <api_c>` always returns either an
 object or an error code:
@@ -400,11 +402,11 @@ Thus, you can always check that everything properly worked.
 
 With the information of the initial positions of the fairlead, you can initialize MoorDyn:
 
-.. doxygenfunction:: MoorDyn_Init()
+.. doxygenfunction:: MoorDyn_Init
 
 Afterwards you can run MoorDyn by calling:
 
-.. doxygenfunction:: MoorDyn_Step()
+.. doxygenfunction:: MoorDyn_Step
 
 In this example, we are just calling it once. In a more complex application the
 function will be called in a loop over a time series. In the API there are a number of 
@@ -414,7 +416,7 @@ complex drivers. The full list of functions can be found in the
 
 It is important to close the MoorDyn system, so that the allocated resources are released:
 
-.. doxygenfunction:: MoorDyn_Close()
+.. doxygenfunction:: MoorDyn_Close
 
 Fortran
 ^^^^^^^

--- a/docs/inputs.rst
+++ b/docs/inputs.rst
@@ -405,8 +405,8 @@ This section (optional) describes the Point objects
  ID   Attachment  X       Y     Z      Mass   Volume  CdA    Ca
  (#)   (word/ID) (m)     (m)   (m)    (kg)   (mˆ3)   (m^2)  (-)
  1     Fixed      -500    0     -150    0      0       0      0
- 4     Coupled    0       0     -9      0      0       0      0
- 11    Body2      0       0     1.0     0      0       0      0
+ 2     Coupled    0       0     -9      0      0       0      0
+ 3    Body2      0       0     1.0     0      0       0      0
  
 The columns are as follows:
 
@@ -638,15 +638,15 @@ loads. When no node number is specified, the output pertains to the object as a 
 values are of the object’s reference point (about the reference point for rotations). Reference 
 Points:
 
-*	Rods: End A (Node 0)
+-	Rods: End A (Node 0)
 
-  * No z rotations for rods (rotations along axis of rod negligible)
-  * A vertical rod with end A below end B is defined as a rod with zero rotation. ROD#RX and ROD#RY 
+  - No z rotations for rods (rotations along axis of rod negligible)
+  - A vertical rod with end A below end B is defined as a rod with zero rotation. ROD#RX and ROD#RY 
     will be zero for this case. 
 
-*	Bodies: Center of Mass
-*	Points: Center of Mass
-*	Lines: End A (Node 0)
+-	Bodies: Center of Mass
+-	Points: Center of Mass
+-	Lines: End A (Node 0)
 
 Footnotes:
 
@@ -768,8 +768,8 @@ The V2 snapshot file
 
 In MoorDyn-C v2 two new functions have been added:
 
-.. doxygenfunction:: MoorDyn_Save()
-.. doxygenfunction:: MoorDyn_Load()
+.. doxygenfunction:: MoorDyn_Save
+.. doxygenfunction:: MoorDyn_Load
 
 With the former a snapshot of the simulation can be saved, so that it can
 be resumed in a different session using the latter function.
@@ -778,7 +778,7 @@ sessions.
 However, the initial equilibrium condition computation can be skipped in the second session by 
 calling
 
-.. doxygenfunction:: MoorDyn_Init_NoIC()
+.. doxygenfunction:: MoorDyn_Init_NoIC
 
 Wave Kinematics file (MoorDyn-C)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/structure.rst
+++ b/docs/structure.rst
@@ -56,10 +56,10 @@ Line objects have the following variables:
 
 General:
 
-- *env*: a pointer to the global environment object
-- *waves*: a pointer to the global object storing information about waves/currents
-- *t*: the simulation time, as a real
-- *seafloor*: a pointer to the global object storing the 3d seafloor information
+* *env*: a pointer to the global environment object
+* *waves*: a pointer to the global object storing information about waves/currents
+* *t*: the simulation time, as a real
+* *seafloor*: a pointer to the global object storing the 3d seafloor information
 
 
 Specific to each Line:

--- a/docs/waterkinematics.rst
+++ b/docs/waterkinematics.rst
@@ -23,10 +23,10 @@ This gives you the ability to set and change the wave kinematics as part of the 
 This uses the ``Moordyn_ExternalWaveKin*`` family of functions to initialize
 and set the wave kinematics as frequently as you want.
 
-.. doxygenfunction:: MoorDyn_ExternalWaveKinInit()
-.. doxygenfunction:: MoorDyn_ExternalWaveKinGetN()
-.. doxygenfunction:: MoorDyn_ExternalWaveKinGetCoordinates()
-.. doxygenfunction:: MoorDyn_ExternalWaveKinSet()
+.. doxygenfunction:: MoorDyn_ExternalWaveKinInit
+.. doxygenfunction:: MoorDyn_ExternalWaveKinGetN
+.. doxygenfunction:: MoorDyn_ExternalWaveKinGetCoordinates
+.. doxygenfunction:: MoorDyn_ExternalWaveKinSet
 
 A standard usage of external wave kinematics would be in some situations where you have your own 
 code or an external program computing the fluid dynamics and you want MoorDyn to use those values.

--- a/source/MoorDyn2.cpp
+++ b/source/MoorDyn2.cpp
@@ -109,9 +109,6 @@ moordyn::MoorDyn::MoorDyn(const char* infilename, int log_level)
 	}
 
 	LOGMSG << "\n Running MoorDyn (v2.a10, 2022-01-01)" << endl
-	       << "   NOTE: This is an alpha version of MoorDyn v2, intended for "
-	          "testing and debugging."
-	       << endl
 	       << "         MoorDyn v2 has significant ongoing input file changes "
 	          "from v1."
 	       << endl
@@ -248,7 +245,7 @@ moordyn::MoorDyn::Init(const double* x, const double* xd, bool skip_ic)
 	}
 
 	for (auto l : CpldPointIs) {
-		LOGMSG << "Initializing coupled Point " << l << " in " << x[ix] << ", "
+		LOGMSG << "Initializing coupled Point " << l+1 << " at " << x[ix] << ", "
 		       << x[ix + 1] << ", " << x[ix + 2] << "..." << endl;
 		vec r, rd;
 		moordyn::array2vec(x + ix, r);


### PR DESCRIPTION
Some more updates to the docs, mostly typos fixes.  A few improvements to compiling instructions based on user feedback. 

@sanguinariojoe was wondering if you could help with a couple docs things:

First, the doxygen function references are not working anymore. I don't think I changed anything but they no longer link. Compare the water kinematics section from [your docs](https://moordyn.readthedocs.io/en/master/waterkinematics.html) and the new [dev docs](https://moordyn.readthedocs.io/en/latest/waterkinematics.html). Could it be a setting on readthedocs that we need to change?

When I compile the docs locally I get the following function errors: 

```
loading pickled environment... done
building [mo]: targets for 0 po files that are out of date
writing output... 
building [html]: targets for 5 source files that are out of date
updating environment: 3 added, 6 changed, 6 removed
reading sources... [100%] waterkinematics
/Users/rdavies/work/MoorDyn_ryan/MoorDyn/docs/api_c.rst:6: WARNING: Error when parsing function declaration.
If the function has no return type:
  Error in declarator or parameters-and-qualifiers
  Invalid C++ declaration: Expected identifier in nested name, got keyword: int [error at 10]
    inline int DECLDIR DEPRECATED MoorDyn_GetWaveKinCoordinates (MoorDyn system, double *r)
    ----------^
If the function has a return type:
  Error in declarator or parameters-and-qualifiers
  If pointer to member declarator:
    Invalid C++ declaration: Expected '::' in pointer to member (function). [error at 30]
      inline int DECLDIR DEPRECATED MoorDyn_GetWaveKinCoordinates (MoorDyn system, double *r)
      ------------------------------^
  If declarator-id:
    Invalid C++ declaration: Expecting "(" in parameters-and-qualifiers. [error at 30]
      inline int DECLDIR DEPRECATED MoorDyn_GetWaveKinCoordinates (MoorDyn system, double *r)
      ------------------------------^

/Users/rdavies/work/MoorDyn_ryan/MoorDyn/docs/api_c.rst:6: WARNING: Error when parsing function declaration.
If the function has no return type:
  Error in declarator or parameters-and-qualifiers
  Invalid C++ declaration: Expected identifier in nested name, got keyword: int [error at 10]
    inline int DECLDIR DEPRECATED MoorDyn_SetWaveKin (MoorDyn system, const double *U, const double *Ud, double t)
    ----------^
If the function has a return type:
  Error in declarator or parameters-and-qualifiers
  If pointer to member declarator:
    Invalid C++ declaration: Expected '::' in pointer to member (function). [error at 30]
      inline int DECLDIR DEPRECATED MoorDyn_SetWaveKin (MoorDyn system, const double *U, const double *Ud, double t)
      ------------------------------^
  If declarator-id:
    Invalid C++ declaration: Expecting "(" in parameters-and-qualifiers. [error at 30]
      inline int DECLDIR DEPRECATED MoorDyn_SetWaveKin (MoorDyn system, const double *U, const double *Ud, double t)
      ------------------------------^

/Users/rdavies/work/MoorDyn_ryan/MoorDyn/docs/drivers.rst:375: WARNING: doxygenfunction: Cannot find function "MoorDyn_Create" in doxygen xml output for project "MoorDyn" from directory: _build/doxygen/xml
/Users/rdavies/work/MoorDyn_ryan/MoorDyn/docs/drivers.rst:393: WARNING: doxygenfunction: Cannot find function "MoorDyn_GetPoint" in doxygen xml output for project "MoorDyn" from directory: _build/doxygen/xml
/Users/rdavies/work/MoorDyn_ryan/MoorDyn/docs/drivers.rst:394: WARNING: doxygenfunction: Cannot find function "MoorDyn_GetPointPos" in doxygen xml output for project "MoorDyn" from directory: _build/doxygen/xml
/Users/rdavies/work/MoorDyn_ryan/MoorDyn/docs/drivers.rst:405: WARNING: doxygenfunction: Cannot find function "MoorDyn_Init" in doxygen xml output for project "MoorDyn" from directory: _build/doxygen/xml
/Users/rdavies/work/MoorDyn_ryan/MoorDyn/docs/drivers.rst:409: WARNING: doxygenfunction: Cannot find function "MoorDyn_Step" in doxygen xml output for project "MoorDyn" from directory: _build/doxygen/xml
/Users/rdavies/work/MoorDyn_ryan/MoorDyn/docs/drivers.rst:419: WARNING: doxygenfunction: Cannot find function "MoorDyn_Close" in doxygen xml output for project "MoorDyn" from directory: _build/doxygen/xml
/Users/rdavies/work/MoorDyn_ryan/MoorDyn/docs/inputs.rst:771: WARNING: doxygenfunction: Cannot find function "MoorDyn_Save" in doxygen xml output for project "MoorDyn" from directory: _build/doxygen/xml
/Users/rdavies/work/MoorDyn_ryan/MoorDyn/docs/inputs.rst:772: WARNING: doxygenfunction: Cannot find function "MoorDyn_Load" in doxygen xml output for project "MoorDyn" from directory: _build/doxygen/xml
/Users/rdavies/work/MoorDyn_ryan/MoorDyn/docs/inputs.rst:781: WARNING: doxygenfunction: Cannot find function "MoorDyn_Init_NoIC" in doxygen xml output for project "MoorDyn" from directory: _build/doxygen/xml
/Users/rdavies/work/MoorDyn_ryan/MoorDyn/docs/waterkinematics.rst:26: WARNING: doxygenfunction: Cannot find function "MoorDyn_ExternalWaveKinInit" in doxygen xml output for project "MoorDyn" from directory: _build/doxygen/xml
/Users/rdavies/work/MoorDyn_ryan/MoorDyn/docs/waterkinematics.rst:27: WARNING: doxygenfunction: Cannot find function "MoorDyn_ExternalWaveKinGetN" in doxygen xml output for project "MoorDyn" from directory: _build/doxygen/xml
/Users/rdavies/work/MoorDyn_ryan/MoorDyn/docs/waterkinematics.rst:28: WARNING: doxygenfunction: Cannot find function "MoorDyn_ExternalWaveKinGetCoordinates" in doxygen xml output for project "MoorDyn" from directory: _build/doxygen/xml
/Users/rdavies/work/MoorDyn_ryan/MoorDyn/docs/waterkinematics.rst:29: WARNING: doxygenfunction: Cannot find function "MoorDyn_ExternalWaveKinSet" in doxygen xml output for project "MoorDyn" from directory: _build/doxygen/xml
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
```

Secondly, bullet points are rendering on my local version of the docs compiled with sphinx, but when readthedocs compiles them they don't show up (for example the [structure section](https://moordyn.readthedocs.io/en/latest/structure.html)). Is this also a readthedocs setting that needs to be adjusted? 