### PR TITLE
Fixing typos, correction to python install instructions

### DIFF
--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -378,6 +378,6 @@ in your system terminal. Pip will take care of everything by you.
 **If you want to use the most up to date version of MoorDyn-C as a python module**, follow the 
 instructions in the :ref:`CMake compile section <CMake_compile>`. Once you have succesfully 
 compiled MoorDyn on your system, change to `MoorDyn/build/wrappers/python/` and execute the 
-following command `python setup.py install`. This will build the python module locally from 
+following command `pip install ./`. This will build the python module locally from 
 the source code you have installed. In order to update this module in the future you will need 
 to update your local source code and follow the same steps above.

--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -378,6 +378,6 @@ in your system terminal. Pip will take care of everything by you.
 **If you want to use the most up to date version of MoorDyn-C as a python module**, follow the 
 instructions in the :ref:`CMake compile section <CMake_compile>`. Once you have succesfully 
 compiled MoorDyn on your system, change to `MoorDyn/build/wrappers/python/` and execute the 
-following command `python3 setup.py install`. This will build the python module locally from 
+following command `python setup.py install`. This will build the python module locally from 
 the source code you have installed. In order to update this module in the future you will need 
 to update your local source code and follow the same steps above.

--- a/docs/drivers.rst
+++ b/docs/drivers.rst
@@ -217,7 +217,7 @@ Notes on the Python C API:
   	 function = functionPROTO(("<function name from C API>", MDdylib), functionParams)
    	
 - Using this method does not call the create function because the v1 API does not allow 
-   for simultaneous MoorDyn instances. 
+  for simultaneous MoorDyn instances. 
 - The initialize function is MDInit.   
 - MoorDyn functions require C data types as inputs.
 
@@ -784,7 +784,8 @@ WEC-Sim
 ^^^^^^^
 
 WEC-Sim is currently coupled with MoorDyn v1. Support for the current version of
-MoorDyn-C v2, is in the process of being developed.
+MoorDyn-C v2, is in the process of being developed. The WEC-Sim source code can be found 
+`here <https://github.com/WEC-Sim/WEC-Sim>`.
 
 DualSPHysics
 ^^^^^^^^^^^^

--- a/docs/inputs.rst
+++ b/docs/inputs.rst
@@ -639,11 +639,9 @@ values are of the object’s reference point (about the reference point for rota
 Points:
 
 -	Rods: End A (Node 0)
-
   - No z rotations for rods (rotations along axis of rod negligible)
   - A vertical rod with end A below end B is defined as a rod with zero rotation. ROD#RX and ROD#RY 
     will be zero for this case. 
-
 -	Bodies: Center of Mass
 -	Points: Center of Mass
 -	Lines: End A (Node 0)

--- a/docs/theory.rst
+++ b/docs/theory.rst
@@ -2,9 +2,9 @@ Features and References
 =======================
 .. _theory:
 
-Most of MoorDyn’s theory is described in published. This page gives a very
-high-level overview, highlights specific theory aspects that may be
-important to users, and lists the papers where more detail can be found.
+Most of MoorDyn’s theory is described in the following publications. This page 
+gives a very high-level overview, highlights specific theory aspects that may 
+be important to users, and lists the papers where more detail can be found.
 
 Features
 --------


### PR DESCRIPTION
Merging and closing, just typos in the docs that I missed. 