### PR TITLE
Body output units bug fix

### DIFF
--- a/source/Body.cpp
+++ b/source/Body.cpp
@@ -305,7 +305,7 @@ real
 Body::GetBodyOutput(OutChanProps outChan)
 {
 
-	vec3 rotations = Quat2Euler(r7.quat);
+	vec3 rotations = rad2deg * Quat2Euler(r7.quat);
 
 	if (outChan.QType == PosX)
 		return r7.pos.x();


### PR DESCRIPTION
Prior to this body rotations, called by the BODY#RX/Y/Z flag, were outputting the body rotation in radians. The standard I/O units should all be degrees. 