### PR TITLE
Fixes initialization location of fixed bodies

### DIFF
--- a/docs/drivers.rst
+++ b/docs/drivers.rst
@@ -157,8 +157,9 @@ library. Below is an example of this on MacOS with MoorDyn compiled as a
    vector_size = 6 # 6DOF coupled object
    size = (len(time), vector_size)
 
-   x = np.zeros(size)
-   xd = np.zeros(size)
+   #specifying correct dtypes for conversion to C types
+   x = np.zeros(size, dtype = float)
+   xd = np.zeros(size, dtype = float)
 
    dylib_path = 'MoorDyn/compile/DYLIB/libmoordyn2.dylib'
    filename = path+rootname+extension

--- a/source/Body.cpp
+++ b/source/Body.cpp
@@ -77,7 +77,15 @@ Body::setup(int number_in,
 		bodyI = I_in;
 		bodyCdA = CdA_in;
 		bodyCa = Ca_in;
-	} else // other types of bodies have no need for these variables...
+	} else if (type == FIXED){ // fixed bodies have no need for these variables other than position...
+		bodyM = 0.0;
+		bodyV = 0.0;
+		body_r6.head<3>() = r6_in.head<3>();
+		body_r6.tail<3>() = deg2rad * r6_in.tail<3>();
+		bodyI = vec::Zero();
+		bodyCdA = vec6::Zero();
+		bodyCa = vec6::Zero();
+    } else // coupled bodies have no need for these variables...
 	{
 		bodyM = 0.0;
 		bodyV = 0.0;
@@ -375,9 +383,10 @@ Body::initiateStep(vec6 r, vec6 rd)
 		rd_ves = rd;
 		return;
 	}
-	if (type == FIXED) // if the ground body, set the BCs to stationary
+	if (type == FIXED) // if fixed body, set the BCs to stationary
 	{
-		r_ves = vec6::Zero();
+		if (bodyId == 0) r_ves = vec6::Zero(); // special ground body case
+		else r_ves = r;
 		rd_ves = vec6::Zero();
 		return;
 	}

--- a/source/MoorDyn2.cpp
+++ b/source/MoorDyn2.cpp
@@ -207,9 +207,7 @@ moordyn::MoorDyn::Init(const double* x, const double* xd, bool skip_ic)
 
 	// intialize fixed bodies and attached objects
 	for (auto l : FixedBodyIs){
-		cout << "Body " << l << endl;
-		cout << BodyList[l]->body_r6 << endl;
-		BodyList[l]->initializeUnfreeBody(BodyList[l]->body_r6, Eigen::DenseBase<Eigen::Vector6d>::Zero());
+		BodyList[l]->initializeUnfreeBody(BodyList[l]->body_r6, vec6::Zero());
 	}
 
 	// initialize coupled objects based on passed kinematics

--- a/source/MoorDyn2.cpp
+++ b/source/MoorDyn2.cpp
@@ -205,6 +205,13 @@ moordyn::MoorDyn::Init(const double* x, const double* xd, bool skip_ic)
 	// call ground body to update all the fixed things...
 	GroundBody->initializeUnfreeBody();
 
+	// intialize fixed bodies and attached objects
+	for (auto l : FixedBodyIs){
+		cout << "Body " << l << endl;
+		cout << BodyList[l]->body_r6 << endl;
+		BodyList[l]->initializeUnfreeBody(BodyList[l]->body_r6, Eigen::DenseBase<Eigen::Vector6d>::Zero());
+	}
+
 	// initialize coupled objects based on passed kinematics
 	int ix = 0;
 
@@ -1732,6 +1739,7 @@ moordyn::MoorDyn::readBody(string inputText)
 		// it is fixed  (this would just be used if someone wanted
 		// to temporarly fix a body that things were attached to)
 		type = Body::FIXED;
+		FixedBodyIs.push_back(ui_size(BodyList));
 	} else if (str::isOneOf(let1, { "VESSEL", "VES", "COUPLED", "CPLD" })) {
 		// it is coupled - controlled from outside
 		type = Body::COUPLED;

--- a/source/MoorDyn2.hpp
+++ b/source/MoorDyn2.hpp
@@ -475,6 +475,8 @@ class MoorDyn final : public io::IO
 
 	/// vector of free body indices in BodyList vector
 	vector<unsigned int> FreeBodyIs;
+	/// vector of fixed body indices in BodyList vector
+	vector<unsigned int> FixedBodyIs;
 	/// vector of coupled/fairlead body indices in BodyList vector
 	vector<unsigned int> CpldBodyIs;
 


### PR DESCRIPTION
Resolves an issue where fixed bodies only initialized at 0,0,0,0,0,0 irregardless of what was specified in the input file. This was due to fixed bodies not initializing, and so default values were used. 