### PR TITLE
Added canonical Euler angles for outputs

### DIFF
--- a/source/Misc.hpp
+++ b/source/Misc.hpp
@@ -142,10 +142,93 @@ typedef ivec3 ivec;
 /// COmplex numbers
 typedef std::complex<real> complex;
 
+inline vec3 
+canonicalEulerAngles(const quaternion& quat, int a0, int a1, int a2)
+{
+	// From issue #163: https://github.com/FloatingArrayDesign/MoorDyn/issues/163
+	mat3 coeff = quat.toRotationMatrix();
+	vec3 res{};
+	using Index = int;
+	using Scalar = real;
+	const Index odd = ((a0 + 1) % 3 == a1) ? 0 : 1;
+	const Index i = a0;
+	const Index j = (a0 + 1 + odd) % 3;
+	const Index k = (a0 + 2 - odd) % 3;
+	if (a0 == a2) {
+		// Proper Euler angles (same first and last axis).
+		// The i, j, k indices enable addressing the input matrix as the XYX
+		// archetype matrix (see Graphics Gems IV), where e.g. coeff(k, i) means
+		// third column, first row in the XYX archetype matrix:
+		//  c2      s2s1              s2c1
+		//  s2s3   -c2s1s3 + c1c3    -c2c1s3 - s1c3
+		// -s2c3    c2s1c3 + c1s3     c2c1c3 - s1s3
+		// Note: s2 is always positive.
+		Scalar s2 = Eigen::numext::hypot(coeff(j, i), coeff(k, i));
+		if (odd) {
+			res[0] = atan2(coeff(j, i), coeff(k, i));
+			// s2 is always positive, so res[1] will be within the canonical [0,
+			// pi] range
+			res[1] = atan2(s2, coeff(i, i));
+		} else {
+			// In the !odd case, signs of all three angles are flipped at the
+			// very end. To keep the solution within the canonical range, we
+			// flip the solution and make res[1] always negative here (since s2
+			// is always positive, -atan2(s2, c2) will always be negative). The
+			// final flip at the end due to !odd will thus make res[1] positive
+			// and canonical. NB: in the general case, there are two correct
+			// solutions, but only one is canonical. For proper Euler angles,
+			// flipping from one solution to the other involves flipping the
+			// sign of the second angle res[1] and adding/subtracting pi to the
+			// first and third angles. The addition/subtraction of pi to the
+			// first angle res[0] is handled here by flipping the signs of
+			// arguments to atan2, while the calculation of the third angle does
+			// not need special adjustment since it uses the adjusted res[0] as
+			// the input and produces a correct result.
+			res[0] = atan2(-coeff(j, i), -coeff(k, i));
+			res[1] = -atan2(s2, coeff(i, i));
+		}
+		// With a=(0,1,0), we have i=0; j=1; k=2, and after computing the first
+		// two angles, we can compute their respective rotation, and apply its
+		// inverse to M. Since the result must be a rotation around x, we have:
+		//
+		//  c2  s1.s2 c1.s2                   1  0   0
+		//  0   c1    -s1       *    M    =   0  c3  s3
+		//  -s2 s1.c2 c1.c2                   0 -s3  c3
+		//
+		//  Thus:  m11.c1 - m21.s1 = c3  &   m12.c1 - m22.s1 = s3
+		Scalar s1 = sin(res[0]);
+		Scalar c1 = cos(res[0]);
+		res[2] = atan2(c1 * coeff(j, k) - s1 * coeff(k, k),
+		               c1 * coeff(j, j) - s1 * coeff(k, j));
+	} else {
+		// Tait-Bryan angles (all three axes are different; typically used for
+		// yaw-pitch-roll calculations). The i, j, k indices enable addressing
+		// the input matrix as the XYZ archetype matrix (see Graphics Gems IV),
+		// where e.g. coeff(k, i) means third column, first row in the XYZ
+		// archetype matrix:
+		//  c2c3    s2s1c3 - c1s3     s2c1c3 + s1s3
+		//  c2s3    s2s1s3 + c1c3     s2c1s3 - s1c3
+		// -s2      c2s1              c2c1
+		res[0] = atan2(coeff(j, k), coeff(k, k));
+		Scalar c2 = Eigen::numext::hypot(coeff(i, i), coeff(i, j));
+		// c2 is always positive, so the following atan2 will always return a
+		// result in the correct canonical middle angle range [-pi/2, pi/2]
+		res[1] = atan2(-coeff(i, k), c2);
+		Scalar s1 = sin(res[0]);
+		Scalar c1 = cos(res[0]);
+		res[2] = atan2(s1 * coeff(k, i) - c1 * coeff(j, i),
+		               c1 * coeff(j, j) - s1 * coeff(k, j));
+	}
+	if (!odd) {
+		res = -res;
+	}
+	return res;
+}
+
 inline vec3
 Quat2Euler(const quaternion& q)
 {
-	return q.toRotationMatrix().eulerAngles(0, 1, 2);
+	return canonicalEulerAngles(q, 0, 1, 2); // 0, 1, 2 correspond to axes leading to XYZ rotation 
 }
 
 inline quaternion

--- a/source/MoorDyn2.cpp
+++ b/source/MoorDyn2.cpp
@@ -1616,8 +1616,8 @@ moordyn::MoorDyn::readRodProps(string inputText)
 	obj->Can = atof(entries[4].c_str());
 	obj->CdEnd = atof(entries[5].c_str());
 	obj->CaEnd = atof(entries[6].c_str());
-	obj->Cdt = 0.0;
-	obj->Cat = 0.0;
+	obj->Cdt = 0.0; // No end effects from internal segments. CdEnd captures end effects.
+	obj->Cat = 0.0; // No end effects from internal segments. CaEnd captures end effects.
 
 	LOGDBG << "\t'" << obj->type << "'"
 	       << " - with id " << RodPropList.size() << endl

--- a/tests/bodies.cpp
+++ b/tests/bodies.cpp
@@ -384,7 +384,7 @@ rotatingBody(SeriesWriter* series_writer)
 	double angle = moordyn::rad2deg * 2 * acos(q.w());
 	double denom = (sqrt(1 - q.w() * q.w()));
 	moordyn::vec3 axis{ q.x() / denom, q.y() / denom, q.z() / denom };
-	if (!(axis.x() > 0.85 && axis.y() < 0.2 && axis.z() < 0.2)) {
+	if (!(abs(axis.x()) > 0.85 && abs(axis.y()) < 0.2 && abs(axis.z()) < 0.2)) { // if we are just checking axis direction then +/- does not matter
 		cerr << "The final rotation of the body in angle axis form should "
 		        "have an axis in the x direction, but axis is "
 		     << axis.transpose() << endl;
@@ -397,7 +397,7 @@ rotatingBody(SeriesWriter* series_writer)
 	while (angle < -180) {
 		angle += 360;
 	}
-	if (!(abs(angle - (-90)) < 10)) {
+	if (!(abs(angle - 90) < 10)) {
 		cerr << "The final rotation of the body in angle-axis form should "
 		        "have a angle near 90 degrees but angle is "
 		     << angle << endl;


### PR DESCRIPTION
Based on discussion in #163 

Adds canonical Euler angles function from Eigen to replace the Euler angle function. This resolves an issue where outputted roll could not be negative, and where certain input body rotations would not be reflected in the output rotation values. This only changes the values written to output files, not internal dynamics. 


Below are outputs before and after the change for a coupled body rotating periodically.

Before:
![outputs before change](https://github.com/FloatingArrayDesign/MoorDyn/assets/101124339/a3d8c7e0-34fa-4221-b347-9549946e17d4)

After:
![after_adjustment](https://github.com/FloatingArrayDesign/MoorDyn/assets/101124339/b0bc9f02-ef9b-4faa-b934-b4bde3c831f6)

@AlexWKinley thanks for putting together the suggested code for this, I only had to make some minor changes. 

We can move this into Misc.cpp if we feel it goes better there. I put it where it is because that's where the Quat2Euler functions are. 
