### PR TITLE
Pinned bodies added

### DIFF
--- a/docs/inputs.rst
+++ b/docs/inputs.rst
@@ -654,6 +654,10 @@ Footnotes:
 - The tension on the Line n anchor can be output with the ANCHTEN[n] flag (see examples above)
 - Object indicates output is for whole object, Node indicates output is for node of object
 - Coupled/fixed bodies and points will output acceleration 0 because no forces are calculated
+- When looking at the rotational outputs of coupled pinned rods that are hanging near vertical, 
+  the best approach is to attach a rod to a zero-mass, zero-volume pinned body and output the body 
+  rotations. Hanging pinned rods are inverted (end A over end B) in MoorDyn and the output range 
+  for roll/pitch of rods is +/- 180 degrees. 
 - There are a couple additional outputs left over from OpenFAST conventions that don’t follow the 
   same format: FairTen and AnchTen. FairTen[n] is the same as Line[n]TenB. For example, the 
   fairlead tension of line 1 would be FAIRTEN1 or LINE1TENB.

--- a/source/Body.cpp
+++ b/source/Body.cpp
@@ -518,7 +518,7 @@ Body::getFnet()
 		F6_iner = - M * a6; // Inertial terms
 		Fnet_out = F6net + F6_iner;
 	} else if (type == CPLDPIN) { // if coupled pinned
-		F6_iner(Eigen::seqN(0,3)) = (- M.topRightCorner<3,3>() * a6(Eigen::seqN(0,3))) - (M.topLeftCorner<3,3>() * a6(Eigen::seqN(3,3))); // Inertial term
+		F6_iner(Eigen::seqN(0,3)) = (- M.topLeftCorner<3,3>() * a6(Eigen::seqN(0,3))) - (M.topRightCorner<3,3>() * a6(Eigen::seqN(3,3))); // Inertial term
 		Fnet_out(Eigen::seqN(0,3)) = F6net(Eigen::seqN(0,3)) + F6_iner(Eigen::seqN(0,3));
 		Fnet_out(Eigen::seqN(3,3)) = vec3::Zero();
 	} else {

--- a/source/Body.cpp
+++ b/source/Body.cpp
@@ -85,6 +85,16 @@ Body::setup(int number_in,
 		bodyI = vec::Zero();
 		bodyCdA = vec6::Zero();
 		bodyCa = vec6::Zero();
+	} else if (type == CPLDPIN){
+		bodyM = M_in;
+		bodyV = V_in;
+
+		body_r6.head<3>() = vec3::Zero();
+		body_r6.tail<3>() = deg2rad * r6_in.tail<3>();
+		body_rCG = rCG_in;
+		bodyI = I_in;
+		bodyCdA = CdA_in;
+		bodyCa = Ca_in;
     } else // coupled bodies have no need for these variables...
 	{
 		bodyM = 0.0;
@@ -181,7 +191,7 @@ Body::initializeUnfreeBody(vec6 r6_in, vec6 v6_in, vec6 a6_in)
 std::pair<XYZQuat, vec6>
 Body::initialize()
 {
-	if (type != FREE) {
+	if ((type != FREE) && (type != CPLDPIN)) {
 		LOGERR << "Invalid initializator for a non FREE body ("
 		       << TypeName(type) << ")" << endl;
 		throw moordyn::invalid_value_error("Invalid body type");

--- a/source/Body.cpp
+++ b/source/Body.cpp
@@ -201,15 +201,17 @@ Body::initialize()
 	// initialized)
 	setDependentStates();
 
-	// If any Rod is fixed to the body (not pinned), initialize it now because
-	// otherwise it won't be initialized
-	for (auto attached : attachedR)
-		if (attached->type == Rod::FIXED)
+	if (type == FREE) { // Attached objects already initalized for coupled pinned body
+		// If any Rod is fixed to the body (not pinned), initialize it now because
+		// otherwise it won't be initialized
+		for (auto attached : attachedR)
+			if (attached->type == Rod::FIXED)
+				attached->initialize();
+		// If there's an attached Point, initialize it now because it won't be
+		// initialized otherwise
+		for (auto attached : attachedP)
 			attached->initialize();
-	// If there's an attached Point, initialize it now because it won't be
-	// initialized otherwise
-	for (auto attached : attachedP)
-		attached->initialize();
+	}
 
 	// create output file for writing output (and write channel header and units
 	// lines) if applicable

--- a/source/Body.cpp
+++ b/source/Body.cpp
@@ -315,6 +315,8 @@ Body::GetBodyOutput(OutChanProps outChan)
 
 	vec3 rotations = rad2deg * Quat2Euler(r7.quat);
 
+	vec6 Fout = getFnet();
+
 	if (outChan.QType == PosX)
 		return r7.pos.x();
 	else if (outChan.QType == PosY)
@@ -355,17 +357,17 @@ Body::GetBodyOutput(OutChanProps outChan)
 		return sqrt(F6net[0] * F6net[0] + F6net[1] * F6net[1] +
 		            F6net[2] * F6net[2]);
 	else if (outChan.QType == FX)
-		return F6net[0];
+		return Fout[0];
 	else if (outChan.QType == FY)
-		return F6net[1];
+		return Fout[1];
 	else if (outChan.QType == FZ)
-		return F6net[2];
+		return Fout[2];
 	else if (outChan.QType == MX)
-		return F6net[3];
+		return Fout[3];
 	else if (outChan.QType == MY)
-		return F6net[4];
+		return Fout[4];
 	else if (outChan.QType == MZ)
-		return F6net[5];
+		return Fout[5];
 	else {
 		LOGWRN << "Unrecognized output channel " << outChan.QType << endl;
 		return 0.0;
@@ -508,8 +510,10 @@ Body::getFnet()
 		Fnet_out(Eigen::seqN(0,3)) = F6net(Eigen::seqN(0,3)) + F6_iner(Eigen::seqN(0,3));
 		Fnet_out(Eigen::seqN(3,3)) = vec3::Zero();
 	} else {
-		LOGERR << "Invalid body type: " << TypeName(type) << endl;
-		throw moordyn::invalid_value_error("Invalid body type");
+		// LOGERR << "Invalid body type: " << TypeName(type) << endl;
+		// throw moordyn::invalid_value_error("Invalid body type");
+
+		Fnet_out = F6net;
 	}
 
 	return Fnet_out;

--- a/source/Body.cpp
+++ b/source/Body.cpp
@@ -325,9 +325,13 @@ real
 Body::GetBodyOutput(OutChanProps outChan)
 {
 
-	vec3 rotations = rad2deg * Quat2Euler(r7.quat);
+	vec3 rotations;
+	vec6 Fout;
 
-	vec6 Fout = getFnet();
+	if ((outChan.QType == RX)||(outChan.QType == RY)||(outChan.QType == RZ))
+		rotations = rad2deg * Quat2Euler(r7.quat);
+	if ((outChan.QType == FX)||(outChan.QType == FY)||(outChan.QType == FZ)||(outChan.QType == MX)||(outChan.QType == MY)||(outChan.QType == MZ))
+		Fout = getFnet();
 
 	if (outChan.QType == PosX)
 		return r7.pos.x();

--- a/source/Body.hpp
+++ b/source/Body.hpp
@@ -134,6 +134,8 @@ class Body final : public io::IO
 	vec6 r_ves;
 	/// fairlead velocity for coupled bodies [x/y/z]
 	vec6 rd_ves;
+	/// fairlead acceleration for coupled bodies [x/y/z]
+	vec6 rdd_ves;
 
 	/// total force and moment vector on body
 	vec6 F6net;
@@ -161,6 +163,8 @@ class Body final : public io::IO
 		FREE = 0,
 		/// Is fixed, either to a location or to another moving entity
 		FIXED = 1,
+		/// Is coupled pinned, i.e. translational dof are controlled by the user
+		CPLDPIN = 2,
 		// Some aliases
 		VESSEL = COUPLED,
 		ANCHOR = FIXED,
@@ -175,6 +179,8 @@ class Body final : public io::IO
 		switch (t) {
 			case COUPLED:
 				return "COUPLED";
+			case CPLDPIN:
+				return "CPLDPIN";	
 			case FREE:
 				return "FREE";
 			case FIXED:
@@ -237,10 +243,11 @@ class Body final : public io::IO
 	 * moordyn::Body::FIXED
 	 * @param r The position (6 dof)
 	 * @param rd The velocity (6 dof)
+	 * @param rdd The acceleration (6 dof)
 	 * @throw moordyn::invalid_value_error If the body is of type
 	 * moordyn::Body::FREE
 	 */
-	void initializeUnfreeBody(vec6 r = vec6::Zero(), vec6 rd = vec6::Zero());
+	void initializeUnfreeBody(vec6 r = vec6::Zero(), vec6 rd = vec6::Zero(), vec6 rdd = vec6::Zero());
 
 	/** @brief Initialize the FREE point state
 	 * @return The 6-dof position (first) and the 6-dof velocity (second)
@@ -317,7 +324,7 @@ class Body final : public io::IO
 	/** @brief Get the forces and moments exerted over the body
 	 * @return The net force
 	 */
-	inline vec6 getFnet() const { return F6net; }
+	vec6 getFnet();
 
 	/** @brief Get the mass and intertia matrix
 	 * @return The mass and inertia matrix
@@ -339,12 +346,13 @@ class Body final : public io::IO
 
 	/** @brief Called at the beginning of each coupling step to update the
 	 * boundary conditions (body kinematics) for the proceeding time steps
-	 * @param r The output position
-	 * @param rd The output velocity
+	 * @param r The input position
+	 * @param rd The input velocity
+	 * @param rdd The input velocity
 	 * @throw moordyn::invalid_value_error If the body is not of type
 	 * moordyn::Body::COUPLED or moordyn::Body::FIXED
 	 */
-	void initiateStep(vec6 r, vec6 rd);
+	void initiateStep(vec6 r_in, vec6 rd_in, vec6 rdd_in);
 
 	/** @brief Sets the kinematics based on the position and velocity of the
 	 * fairlead.

--- a/source/Line.hpp
+++ b/source/Line.hpp
@@ -409,6 +409,14 @@ class Line final : public io::IO
 			       << ", which only has " << N + 1 << " nodes" << std::endl;
 			throw moordyn::invalid_value_error("Invalid node index");
 		}
+		if (isnan(r[i].sum())) {
+			stringstream s;
+			s << "NaN detected" << endl
+			  << "Line " << number << " node positions:" << endl;
+			for (unsigned int j = 0; j <= N; j++)
+				s << j << " : " << r[j] << ";" << endl;
+			throw moordyn::nan_error(s.str().c_str());
+		}
 		return r[i];
 	}
 

--- a/source/Misc.hpp
+++ b/source/Misc.hpp
@@ -672,7 +672,9 @@ split(const string& str, const char sep);
 inline vector<string>
 split(const string& s)
 {
-	return split(s, ' ');
+	vector<string> sout = split(s, ' ');
+	if (sout.size() == 1) return split(sout[0], '	');
+	else return sout;
 }
 
 /**

--- a/source/MoorDyn2.cpp
+++ b/source/MoorDyn2.cpp
@@ -512,7 +512,7 @@ moordyn::MoorDyn::Step(const double* x,
 	// should check if wave kinematics have been set up if expected!
 	LOGDBG << "t = " << t << "s     \r";
 
-	cout << "\rtime: " << t << flush;
+	if (t*10 == int(t*10)) cout << "\rtime: " << t << flush;
 
 	if (dt <= 0) {
 		// Nothing to do, just recover the forces if there are coupled DOFs

--- a/source/MoorDyn2.cpp
+++ b/source/MoorDyn2.cpp
@@ -214,7 +214,7 @@ moordyn::MoorDyn::Init(const double* x, const double* xd, bool skip_ic)
 	int ix = 0;
 
 	for (auto l : CpldBodyIs) {
-		LOGMSG << "Initializing coupled Body " << l << " in " << x[ix] << ", "
+		LOGMSG << "Initializing coupled Body " << l+1 << " at " << x[ix] << ", "
 		       << x[ix + 1] << ", " << x[ix + 2] << "..." << endl;
 
 		// BUG: These conversions will not be needed in the future
@@ -244,7 +244,7 @@ moordyn::MoorDyn::Init(const double* x, const double* xd, bool skip_ic)
 	}
 
 	for (auto l : CpldRodIs) {
-		LOGMSG << "Initializing coupled Rod " << l << " in " << x[ix] << ", "
+		LOGMSG << "Initializing coupled Rod " << l+1 << " at " << x[ix] << ", "
 		       << x[ix + 1] << ", " << x[ix + 2] << "..." << endl;
 		vec6 r, rd, rdd;
 		if (RodList[l]->type == Rod::COUPLED) {
@@ -277,7 +277,7 @@ moordyn::MoorDyn::Init(const double* x, const double* xd, bool skip_ic)
 
 	for (auto l : CpldPointIs) {
 		LOGMSG << "Initializing coupled Point " << l+1 << " at " << x[ix] << ", "
-		       << x[ix + 1] << ", " << x[ix + 2] << "..." << endl;
+		       << x[ix + 1] << ", " << x[ix + 2] << endl;
 		vec r, rd;
 		moordyn::array2vec(x + ix, r);
 		moordyn::array2vec(xd + ix, rd);
@@ -511,6 +511,8 @@ moordyn::MoorDyn::Step(const double* x,
 {
 	// should check if wave kinematics have been set up if expected!
 	LOGDBG << "t = " << t << "s     \r";
+
+	cout << "\rtime: " << t << flush;
 
 	if (dt <= 0) {
 		// Nothing to do, just recover the forces if there are coupled DOFs

--- a/source/MoorDyn2.cpp
+++ b/source/MoorDyn2.cpp
@@ -1400,7 +1400,7 @@ moordyn::MoorDyn::ReadInFile()
 					} else if (let3 == "AX") {
 						dummy.QType = AccX;
 						dummy.Units = moordyn::UnitList[AccX];
-					} else if (let3 == "Ay") {
+					} else if (let3 == "AY") {
 						dummy.QType = AccY;
 						dummy.Units = moordyn::UnitList[AccY];
 					} else if (let3 == "AZ") {

--- a/source/MoorDyn2.cpp
+++ b/source/MoorDyn2.cpp
@@ -512,7 +512,8 @@ moordyn::MoorDyn::Step(const double* x,
 	// should check if wave kinematics have been set up if expected!
 	LOGDBG << "t = " << t << "s     \r";
 
-	if (t*10 == int(t*10)) cout << "\rtime: " << t << flush;
+	cout << fixed << setprecision(1);
+	cout << "\rt = " << t << flush;
 
 	if (dt <= 0) {
 		// Nothing to do, just recover the forces if there are coupled DOFs

--- a/source/MoorDyn2.cpp
+++ b/source/MoorDyn2.cpp
@@ -513,7 +513,7 @@ moordyn::MoorDyn::Step(const double* x,
 	LOGDBG << "t = " << t << "s     \r";
 
 	cout << fixed << setprecision(1);
-	cout << "\rt = " << t << flush;
+	cout << "\rt = " << t << " " << flush;
 
 	if (dt <= 0) {
 		// Nothing to do, just recover the forces if there are coupled DOFs
@@ -552,7 +552,7 @@ moordyn::MoorDyn::Step(const double* x,
 			moordyn::array2vec(xd + ix, rd3);
 			rd(Eigen::seqN(0, 3)) = rd3;
 			// determine acceleration 
-		    rdd(Eigen::seqN(0, 3)) = (rd3 - rd3_b) / dtM0;
+		    rdd(Eigen::seqN(0, 3)) = (rd3 - rd3_b) / dt;
 			rd3_b = rd3;
 
 			ix += 3;
@@ -566,7 +566,7 @@ moordyn::MoorDyn::Step(const double* x,
 			moordyn::array2vec6(x + ix, r);
 			moordyn::array2vec6(xd + ix, rd);
 			// determine acceleration 
-		    rdd = (rd - rd_r) / dtM0;
+		    rdd = (rd - rd_r) / dt;
 			rd_r = rd;
 
 			ix += 6;
@@ -578,7 +578,7 @@ moordyn::MoorDyn::Step(const double* x,
 			moordyn::array2vec(xd + ix, rd3);
 			rd(Eigen::seqN(0, 3)) = rd3;
 			// determine acceleration 
-		    rdd(Eigen::seqN(0, 3)) = (rd3 - rd3_r) / dtM0;
+		    rdd(Eigen::seqN(0, 3)) = (rd3 - rd3_r) / dt;
 			rd3_r = rd3;
 
 			ix += 3;

--- a/source/MoorDyn2.cpp
+++ b/source/MoorDyn2.cpp
@@ -1836,7 +1836,7 @@ moordyn::MoorDyn::readRod(string inputText)
 		type = Rod::COUPLED;
 		CpldRodIs.push_back(
 		    ui_size(RodList)); // index of fairlead in RodList vector
-	} else if (str::isOneOf(let1, { "VESPIN", "CPLDPIN" })) {
+	} else if (str::isOneOf(let1, { "VESPIN", "CPLDPIN", "COUPLEDPINNED" })) {
 		// if a pinned fairlead, add to list and add
 		type = Rod::CPLDPIN;
 		CpldRodIs.push_back(

--- a/source/MoorDyn2.hpp
+++ b/source/MoorDyn2.hpp
@@ -508,10 +508,10 @@ class MoorDyn final : public io::IO
 	unsigned int npW;
 
 	/// Previous time step velocity for calculating coupled point acceleration (first time step assumed stationary)
-	vec6 rd_b; // body
-	vec6 rd_r; // coupled rod
-	vec3 rd3_r; // coupled pinned rod
-	vec3 rd3_b; // coupled pinned body
+	vec6 rd_b = vec6::Zero(); // body
+	vec6 rd_r = vec6::Zero(); // coupled rod
+	vec3 rd3_r = vec3::Zero(); // coupled pinned rod
+	vec3 rd3_b = vec3::Zero(); // coupled pinned body
 
 	/// main output file
 	ofstream outfileMain;

--- a/source/MoorDyn2.hpp
+++ b/source/MoorDyn2.hpp
@@ -388,8 +388,13 @@ class MoorDyn final : public io::IO
 		for (auto l : CpldBodyIs) {
 			// BUG: These conversions will not be needed in the future
 			const vec6 f_i = BodyList[l]->getFnet();
-			moordyn::vec62array(f_i, f + ix);
-			ix += 6;
+			if (BodyList[l]->type == Body::COUPLED) {
+				moordyn::vec62array(f_i, f + ix);
+				ix += 6; // for coupled bodies 6 entries will be taken
+			} else {
+				moordyn::vec2array(f_i(Eigen::seqN(0, 3)), f + ix);
+				ix += 3; // for pinned bodies 3 entries will be taken
+			}
 		}
 		for (auto l : CpldRodIs) {
 			const vec6 f_i = RodList[l]->getFnet();
@@ -501,6 +506,12 @@ class MoorDyn final : public io::IO
 	/// number of points that wave kinematics are input at
 	/// (if using env.WaveKin=1)
 	unsigned int npW;
+
+	/// Previous time step velocity for calculating coupled point acceleration (first time step assumed stationary)
+	vec6 rd_b; // body
+	vec6 rd_r; // coupled rod
+	vec3 rd3_r; // coupled pinned rod
+	vec3 rd3_b; // coupled pinned body
 
 	/// main output file
 	ofstream outfileMain;

--- a/source/Rod.cpp
+++ b/source/Rod.cpp
@@ -696,7 +696,7 @@ Rod::getFnet()
 		F6_iner = - M6net * acc6; // Inertial terms
 		Fnet_out = F6net + F6_iner;
 	} else if (type == CPLDPIN) { // if coupled pinned
-		F6_iner(Eigen::seqN(0,3)) = (- M6net.topRightCorner<3,3>() * acc6(Eigen::seqN(0,3))) - (M6net.topLeftCorner<3,3>() * acc6(Eigen::seqN(3,3))); // Inertial term
+		F6_iner(Eigen::seqN(0,3)) = (- M6net.topLeftCorner<3,3>() * acc6(Eigen::seqN(0,3))) - (M6net.topRightCorner<3,3>() * acc6(Eigen::seqN(3,3))); // Inertial term
 		Fnet_out(Eigen::seqN(0,3)) = F6net(Eigen::seqN(0,3)) + F6_iner(Eigen::seqN(0,3));
 		Fnet_out(Eigen::seqN(3,3)) = vec3::Zero();
 	} else {

--- a/source/Rod.cpp
+++ b/source/Rod.cpp
@@ -148,12 +148,13 @@ Rod::setup(int number_in,
 	if (type == FREE) {
 		// For an independent rod, set the position right off the bat
 		r7.pos = endCoords.head<3>();
-		r7.quat = quaternion::Identity();
+		r7.quat = quaternion::FromTwoVectors(q0, endCoords.tail<3>());
 		v6 = vec6::Zero();
 	} else if ((type == PINNED) || (type == CPLDPIN)) {
 		// for a pinned rod, just set the orientation (position will be set
-		// later by parent object)
-		r7 = XYZQuat::Zero();
+		// later by parent object) 
+		r7.pos = vec3::Zero(); 
+		r7.quat = quaternion::FromTwoVectors(q0, endCoords.tail<3>()); // TODO: Check this is right
 		v6(Eigen::seqN(3, 3)) = vec::Zero();
 	}
 	// otherwise (for a fixed rod) the positions will be set by the parent body
@@ -511,7 +512,7 @@ Rod::setKinematics(vec6 r_in, vec6 rd_in)
 		// since this rod has no states and all DOFs have been set, pass its
 		// kinematics to dependent Lines
 		setDependentStates();
-	} else if (type == PINNED) // rod end A pinned to a body
+	} else if ((type == PINNED) || (type == CPLDPIN))// rod end A pinned to a body
 	{
 		// set Rod *end A only* kinematics based on BCs (linear model for now)
 		r7.pos = r_in(Eigen::seqN(0, 3));

--- a/source/Rod.cpp
+++ b/source/Rod.cpp
@@ -337,6 +337,8 @@ Rod::initialize()
 real
 Rod::GetRodOutput(OutChanProps outChan)
 {
+	vec6 Fout = getFnet();
+
 	if (outChan.NodeID == -1) {
 		if (outChan.QType == PosX)
 			return r7.pos.x();
@@ -373,17 +375,17 @@ Rod::GetRodOutput(OutChanProps outChan)
 		else if (outChan.QType == TenB)
 			return FextB.norm();
 		else if (outChan.QType == FX)
-			return F6net[0];
+			return Fout[0];
 		else if (outChan.QType == FY)
-			return F6net[1];
+			return Fout[1];
 		else if (outChan.QType == FZ)
-			return F6net[2];
+			return Fout[2];
 		else if (outChan.QType == MX)
-			return F6net[3];
+			return Fout[3];
 		else if (outChan.QType == MY)
-			return F6net[4];
+			return Fout[4];
 		else if (outChan.QType == MZ)
-			return F6net[5];
+			return Fout[5];
 		else if (outChan.QType == Sub) {
 			real VOFsum = 0.0;
 			for (unsigned int i = 0; i <= N; i++)
@@ -697,8 +699,10 @@ Rod::getFnet()
 		Fnet_out(Eigen::seqN(0,3)) = F6net(Eigen::seqN(0,3)) + F6_iner(Eigen::seqN(0,3));
 		Fnet_out(Eigen::seqN(3,3)) = vec3::Zero();
 	} else {
-		LOGERR << "Invalid rod type: " << TypeName(type) << endl;
-		throw moordyn::invalid_value_error("Invalid rod type");
+		// LOGERR << "Invalid rod type: " << TypeName(type) << endl;
+		// throw moordyn::invalid_value_error("Invalid rod type");
+
+		Fnet_out = F6net;
 	}
 
 	// // now go through each node's contributions, put them in body ref frame, and

--- a/source/Rod.cpp
+++ b/source/Rod.cpp
@@ -338,7 +338,11 @@ Rod::initialize()
 real
 Rod::GetRodOutput(OutChanProps outChan)
 {
-	vec6 Fout = getFnet();
+	
+	vec6 Fout;
+	if ((outChan.QType == FX)||(outChan.QType == FY)||(outChan.QType == FZ)||(outChan.QType == MX)||(outChan.QType == MY)||(outChan.QType == MZ))
+		Fout = getFnet();
+
 
 	if (outChan.NodeID == -1) {
 		if (outChan.QType == PosX)

--- a/source/Rod.hpp
+++ b/source/Rod.hpp
@@ -365,6 +365,14 @@ class Rod final : public io::IO
 			       << ", which only has " << N + 1 << " nodes" << std::endl;
 			throw moordyn::invalid_value_error("Invalid node index");
 		}
+		if (isnan(r[i].sum())) {
+			stringstream s;
+			s << "NaN detected" << endl
+			  << "Rod " << number << " node positions:" << endl;
+			for (unsigned int j = 0; j <= N; j++)
+				s << j << " : " << r[j] << ";" << endl;
+			throw moordyn::nan_error(s.str().c_str());
+		}
 		return r[i];
 	}
 

--- a/source/Rod.hpp
+++ b/source/Rod.hpp
@@ -203,6 +203,8 @@ class Rod final : public io::IO
 	vec6 r_ves;
 	/// fairlead velocity for coupled rods [x/y/z]
 	vec6 rd_ves;
+	/// fairlead acceleration for coupled rods [x/y/z]
+	vec6 rdd_ves;
 
 	// file stuff
 	/// Pointer to moordyn::MoorDyn::outfileMain
@@ -442,14 +444,15 @@ class Rod final : public io::IO
 
 	/** @brief Called at the beginning of each coupling step to update the
 	 * boundary conditions (rod kinematics) for the proceeding time steps
-	 * @param r The output position
-	 * @param rd The output velocity
+	 * @param r The input position
+	 * @param rd The input velocity
+	 * @param rdd The input velocity
 	 * @throw moordyn::invalid_value_error If the rod is not of type
 	 * moordyn::Rod::COUPLED or moordyn::Rod::CPLDPIN
 	 * @note If the rod is of type moordyn::Rod::CPLDPIN, then just 3 components
 	 * of @p r and @p rd are considered
 	 */
-	void initiateStep(vec6 r, vec6 rd);
+	void initiateStep(vec6 r_in, vec6 rd_in, vec6 rdd_in);
 
 	/** @brief Sets the kinematics
 	 *

--- a/source/Time.cpp
+++ b/source/Time.cpp
@@ -44,7 +44,7 @@ TimeSchemeBase<NSTATE, NDERIV>::Update(real t_local, unsigned int substep)
 
 	t_local += this->t_local;
 	for (auto obj : bodies) {
-		if (obj->type != Body::COUPLED)
+		if ((obj->type != Body::COUPLED) && (obj->type != Body::CPLDPIN))
 			continue;
 		obj->updateFairlead(t_local);
 	}
@@ -63,7 +63,7 @@ TimeSchemeBase<NSTATE, NDERIV>::Update(real t_local, unsigned int substep)
 	}
 
 	for (unsigned int i = 0; i < bodies.size(); i++) {
-		if (bodies[i]->type != Body::FREE)
+		if ((bodies[i]->type != Body::FREE) && (bodies[i]->type != Body::CPLDPIN))
 			continue;
 		bodies[i]->setState(r[substep].bodies[i].pos, r[substep].bodies[i].vel);
 	}
@@ -115,7 +115,7 @@ TimeSchemeBase<NSTATE, NDERIV>::CalcStateDeriv(unsigned int substep)
 	}
 
 	for (unsigned int i = 0; i < bodies.size(); i++) {
-		if (bodies[i]->type != Body::FREE)
+		if ((bodies[i]->type != Body::FREE) && (bodies[i]->type != Body::CPLDPIN))
 			continue;
 		std::tie(rd[substep].bodies[i].vel, rd[substep].bodies[i].acc) =
 		    bodies[i]->getStateDeriv();
@@ -127,7 +127,7 @@ TimeSchemeBase<NSTATE, NDERIV>::CalcStateDeriv(unsigned int substep)
 		obj->doRHS();
 	}
 	for (auto obj : rods) {
-		if ((obj->type != Rod::COUPLED) && (obj->type != Rod::CPLDPIN))
+		if (obj->type != Rod::COUPLED)
 			continue;
 		obj->doRHS();
 	}

--- a/source/Time.hpp
+++ b/source/Time.hpp
@@ -494,14 +494,14 @@ class TimeSchemeBase : public TimeScheme
 		// integrator, no matter if they are free or not. Thus they can change
 		// types (mutate) without needing to micromanage them in the time scheme
 		for (unsigned int i = 0; i < bodies.size(); i++) {
-			if (bodies[i]->type != Body::FREE)
+			if ((bodies[i]->type != Body::FREE) && (bodies[i]->type != Body::CPLDPIN))
 				continue;
 			std::tie(r[0].bodies[i].pos, r[0].bodies[i].vel) =
 			    bodies[i]->initialize();
 		}
 
 		for (unsigned int i = 0; i < rods.size(); i++) {
-			if ((rods[i]->type != Rod::FREE) && (rods[i]->type != Rod::PINNED))
+			if ((rods[i]->type != Rod::FREE) && (rods[i]->type != Rod::PINNED) && (rods[i]->type != Rod::CPLDPIN))
 				continue;
 			std::tie(r[0].rods[i].pos, r[0].rods[i].vel) =
 			    rods[i]->initialize();

--- a/source/Time.hpp
+++ b/source/Time.hpp
@@ -494,14 +494,14 @@ class TimeSchemeBase : public TimeScheme
 		// integrator, no matter if they are free or not. Thus they can change
 		// types (mutate) without needing to micromanage them in the time scheme
 		for (unsigned int i = 0; i < bodies.size(); i++) {
-			if ((bodies[i]->type != Body::FREE) && (bodies[i]->type != Body::CPLDPIN))
+			if ((bodies[i]->type != Body::FREE) && (bodies[i]->type != Body::CPLDPIN)) // Only fully coupled bodies are intialized in MD2.cpp
 				continue;
 			std::tie(r[0].bodies[i].pos, r[0].bodies[i].vel) =
 			    bodies[i]->initialize();
 		}
 
 		for (unsigned int i = 0; i < rods.size(); i++) {
-			if ((rods[i]->type != Rod::FREE) && (rods[i]->type != Rod::PINNED) && (rods[i]->type != Rod::CPLDPIN))
+			if ((rods[i]->type != Rod::FREE) && (rods[i]->type != Rod::PINNED))
 				continue;
 			std::tie(r[0].rods[i].pos, r[0].rods[i].vel) =
 			    rods[i]->initialize();

--- a/tests/Mooring/body_tests/pinnedBody.txt
+++ b/tests/Mooring/body_tests/pinnedBody.txt
@@ -1,0 +1,43 @@
+The points and line are dummy objects just to allow MD to run w/o error
+------------------------- LINE TYPES --------------------------------------------------
+LineType  Diam    MassDenInAir    EA       BA/-zeta    EI      Can   Cat  Cdn   Cdt 
+(-)       (m)       (kg/m)        (N)      (Pa-s/-)  (n-m^2)   (-)   (-)  (-)   (-)  
+nylon      0.124      35.0    5515288.0     -0.8      0.0     1.0   0.0  1.6   0.05
+---------------------- ROD TYPES ------------------------------------
+TypeName      Diam     Mass/m    Cd     Ca      CdEnd    CaEnd
+(name)        (m)      (kg/m)    (-)    (-)     (-)      (-)
+Can          2       5e3     0.6    1.0     1.2      1.0
+----------------------- BODIES ------------------------------------------------------
+ID   Attachment         X0      Y0     Z0     r0      p0     y0     Mass          CG*          I*      Volume   CdA*   Ca*
+(#)     (-)             (m)     (m)    (m)   (deg)   (deg)  (deg)   (kg)          (m)         (kg-m^2)  (m^3)   (m^2)  (-)
+1     CoupledPinned    0.00    0.00  -5.00   0.00   0.00   0.00   0.00        0.00        0.000e+00  0.00     0.00  0.00
+---------------------- RODS ----------------------------------------
+ID   RodType  Attachment     Xa    Ya    Za    Xb    Yb     Zb    NumSegs  RodOutputs
+(#)  (name)    (#/key)      (m)   (m)   (m)   (m)   (m)    (m)   (-)       (-)
+1      Can     Body1         0     0     -5     0     0     -15     3         p
+----------------------- POINTS ----------------------------------------------
+Node      Type      X        Y         Z        M        V         CdA   CA
+(-)       (-)      (m)      (m)       (m)      (kg)     (m^3)     (m^2)  (-)
+1         Fixed    30    0      -5       0        0          0     0
+2         Fixed    30    0      -10       0        0          0     0
+-------------------------- LINES -------------------------------------------------
+Line     LineType NodeA     NodeB  UnstrLen  NumSegs     Flags/Outputs
+(-)      (-)       (-)       (-)   (m)         (-)          (-)
+1        nylon      1         2    5        1           p
+-------------------------- SOLVER OPTIONS---------------------------------------------------
+2        writeLog     - Write a log file
+0.0     WtrDnsty     - Water Density
+0.001   dtM          - time step to use in mooring integration
+3.0e6    kb           - bottom stiffness
+3.0e5    cb           - bottom damping
+30       WtrDpth      - water depth
+0.015    threshIC     - threshold for IC convergence
+0.0    TmaxIC       - threshold for IC convergence
+0.01     dtIC         - Time lapse between convergence tests (s)
+------------------------------ OUTPUTS -----------------------------------------------------
+BODY1RX
+BODY1RY
+BODY1PX
+BODY1PY
+BODY1AY
+--------------------------- need this line -------------------------------------------------


### PR DESCRIPTION
Successfully updated rebase so now it should avoid duplicates with dev branch.

**Original commit message from #178:**

This PR includes a new option for bodies, allowing them to behave as a pinned object. It contains a corresponding unit test and documentation updates. It also contains a feature update that prints time steps to the terminal while running, similar to how MDF works at runtime.

The formulation follows the pinned rods orientation closely. Inertial responses and forces have been added to the getStateDeriv and getFnet functions for both bodies and rods. The torque from translational acceleration is:
F_iner [4:6] = M.bottomLeftCorner * a6[1:3]

and the inertial response force to acceleration is given as (contains two terms to avoid counting the externally applied force):
F_iner[1:3] = - M.topLeftCorner * a6[1:3] - M.topRightCorner * a6[3:6]

This feature has been verified in MDF using CAD software, analytical solutions, and Subdyn. For the MDC version I verified using MDF, and the two versions match very closely.

The corresponding update will be included in OpenFAST v4.

This update did require the addition of an acceleration term for each calling time step for the calculation of inertial forces. In MDF acceleration a value passed into the step function. For MDC, I did this the same way velocity is handled: constant over the coupling step. While this isn't the most accurate, it was the simplest approach and in most use cases the coupling time step will be small enough that the effect is negligible (there was never issues when comparing with MDF).