### PR TITLE
Point the dependabot against dev branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,4 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    target-branch: "dev"


### PR DESCRIPTION
Dependabot is constantly opening PRs against master, but on our developing system those shall be added to dev instead