### PR TITLE
mukunku/tag-exists-action from 1.5.0 to 1.6.0

### DIFF
--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -21,7 +21,7 @@ jobs:
         echo "moordyn_version=$major.$minor.$patch" >> $GITHUB_OUTPUT
 
     - name: Tag check
-      uses: mukunku/tag-exists-action@v1.5.0
+      uses: mukunku/tag-exists-action@v1.6.0
       id: checkTag
       with:
         tag: "v${{steps.moordyn_version.outputs.moordyn_version}}"


### PR DESCRIPTION
To replace https://github.com/FloatingArrayDesign/MoorDyn/pull/187, which has conflicts