### PR TITLE
Give back the same values by the output channels

### DIFF
--- a/source/Line.cpp
+++ b/source/Line.cpp
@@ -531,12 +531,15 @@ Line::GetLineOutput(OutChanProps outChan)
 		return rd[outChan.NodeID][1];
 	else if (outChan.QType == VelZ)
 		return rd[outChan.NodeID][2];
-	else if (outChan.QType == Ten)
-		return getNodeTen(outChan.NodeID).norm();
+	else if (outChan.QType == Ten) {
+		if ((outChan.NodeID == 0) || (outChan.NodeID == N))
+			return getNodeForce(outChan.NodeID).norm();
+		return (0.5 * (T[outChan.NodeID] + T[outChan.NodeID - 1])).norm();
+	}
 	else if (outChan.QType == TenA)
-		return getNodeTen(0).norm();
+		return getNodeForce(0).norm();
 	else if (outChan.QType == TenB)
-		return getNodeTen(N).norm();
+		return getNodeForce(N).norm();
 	else if (outChan.QType == FX)
 		return Fnet[outChan.NodeID][0];
 	else if (outChan.QType == FY)
@@ -1512,7 +1515,9 @@ Line::drawGL(void)
 	double normTen;
 	double rgb[3];
 	for (int i = 0; i <= N; i++) {
-		double newTen = getNodeTen(i).norm();
+		const double newTen = ((i == 0) || (i == N)) ?
+			getNodeForce(i).norm() :
+			(0.5 * (T[i] + T[i - 1])).norm();
 		if (newTen > maxTen)
 			maxTen = newTen;
 	}
@@ -1522,7 +1527,9 @@ Line::drawGL(void)
 	for (int i = 0; i <= N; i++) {
 		glVertex3d(r[i][0], r[i][1], r[i][2]);
 		if (i < N) {
-			normTen = getNodeTen(i).norm() / maxTen;
+			const double normTen = ((i == 0) || (i == N)) ?
+				getNodeForce(i).norm() :
+				(0.5 * (T[i] + T[i - 1])).norm();
 			ColorMap(normTen, rgb);
 			glColor3d(rgb[0], rgb[1], rgb[2]);
 		}
@@ -1537,14 +1544,18 @@ Line::drawGL2(void)
 	double normTen;
 	double rgb[3];
 	for (int i = 0; i <= N; i++) {
-		double newTen = getNodeTen(i).norm();
+		const double newTen = ((i == 0) || (i == N)) ?
+			getNodeForce(i).norm() :
+			(0.5 * (T[i] + T[i - 1])).norm();
 		if (newTen > maxTen)
 			maxTen = newTen;
 	}
 
 	// line
 	for (unsigned int i = 0; i < N; i++) {
-		normTen = 0.2 + 0.8 * pow(getNodeTen(i).norm() / maxTen, 4.0);
+		const double normTen = 0.2 + 0.8 * pow(((i == 0) || (i == N)) ?
+			getNodeForce(i).norm() :
+			(0.5 * (T[i] + T[i - 1])).norm(), 4.0);
 		ColorMap(normTen, rgb);
 		glColor3d(rgb[0], rgb[1], rgb[2]);
 


### PR DESCRIPTION
This should fix the problem found by @RyanDavies19 at https://github.com/FloatingArrayDesign/MoorDyn/pull/202

The API still works the new way though.

As I suppose it can be appreciated, the former way is quite inconsistent, at least with respect the fairlead and the anchor. Maybe it would be good to take the axial damping out to it own API method (`MoorDyn_GetLineNodeTenD()` and `moordyn::Line::getNodeTenD()`)