### PR TITLE
Bending due to pressure forces

### DIFF
--- a/source/Body.cpp
+++ b/source/Body.cpp
@@ -560,7 +560,7 @@ Body::doRHS()
 
 	// env->waves->getU(r6, t, U); // call generic function to get water
 	// velocities <<<<<<<<< all needs updating
-	auto [zeta, U, Ud] = waves->getWaveKinBody(bodyId);
+	auto [zeta, U, Ud, Pdyn] = waves->getWaveKinBody(bodyId);
 
 	// ------------------------------------------------------------------------------------------
 

--- a/source/Line.cpp
+++ b/source/Line.cpp
@@ -776,7 +776,7 @@ Line::getStateDeriv()
 		const double ldstr_top = (r[i + 1] - r[i]).dot(rd[i + 1] - rd[i]);
 		ldstr[i] = ldstr_top / lstr[i]; // strain rate of segment
 
-		V[i] = A * l[i]; // volume attributed to segment
+		// V[i] = A * l[i]; // volume attributed to segment
 	}
 
 	// calculate unit tangent vectors (q) for each internal node. note: I've
@@ -822,13 +822,13 @@ Line::getStateDeriv()
 
 		if (i == 0) {
 			m_i = pi / 8. * d * d * l[0] * rho;
-			v_i = 1. / 2. * F[i] * V[i];
+			v_i = 0.5 * F[0] * V[0];
 		} else if (i == N) {
 			m_i = pi / 8. * d * d * l[N - 1] * rho;
-			v_i = 1. / 2. * F[i - 1] * V[i - 1];
+			v_i = 0.5 * F[i - 1] * V[i - 1];
 		} else {
 			m_i = pi / 8. * (d * d * rho * (l[i] + l[i - 1]));
-			v_i = 1. / 2. * (F[i - 1] * V[i - 1] + F[i] * V[i]);
+			v_i = 0.5 * (F[i - 1] * V[i - 1] + F[i] * V[i]);
 		}
 
 		// Make node mass matrix
@@ -864,7 +864,7 @@ Line::getStateDeriv()
 	// Bending loads
 	// first zero out the forces from last run
 	for (unsigned int i = 0; i <= N; i++)
-		Bs[i] = vec(0.0, 0.0, 0.0);
+		Bs[i] = vec::Zero();
 
 	// and now compute them (if possible)
 	if (isEI) {

--- a/source/Line.cpp
+++ b/source/Line.cpp
@@ -1070,7 +1070,7 @@ Line::getStateDeriv()
 			if (EqualRealNos(Kurvi, 0.0))
 				continue;
 			// The driving pressure
-			const real h = zeta[i] - r[i].z();
+			const real h = (std::max)(0.0, zeta[i] - r[i].z());
 			const real p = pin[i] - (env->rho_w * env->g * h + pdyn[i]);
 			// The direction
 			const vec nvec = q[i].cross(pvec[i]);

--- a/source/Line.h
+++ b/source/Line.h
@@ -138,6 +138,38 @@ extern "C"
 	 */
 	int DECLDIR MoorDyn_SetLineConstantEA(MoorDynLine l, double EA);
 
+	/** @brief Get whether the line pressure bending is considered or not
+	 * @param l The Moordyn line
+	 * @param b 1 if the pressure bending of the line is enabled, 0 otherwise
+	 * @return MOORDYN_INVALID_VALUE if a NULL line is provided, MOORDYN_SUCCESS
+	 * otherwise
+	 * @see MoorDyn_SetLinePressBend()
+	 * @see MoorDyn_SetLinePressInt()
+	 */
+	int DECLDIR MoorDyn_IsLinePressBend(MoorDynLine l, int* b);
+
+	/** @brief Set whether the line pressure bending is considered or not
+	 * @param l The Moordyn line
+	 * @param b 1 if the pressure bending of the line shall be considered, 0
+	 * otherwise
+	 * @return MOORDYN_INVALID_VALUE if a NULL line is provided, MOORDYN_SUCCESS
+	 * otherwise
+	 * @see MoorDyn_IsLinePressBend()
+	 * @see MoorDyn_SetLinePressInt()
+	 */
+	int DECLDIR MoorDyn_SetLinePressBend(MoorDynLine l, int b);
+
+	/** @brief Set the line internal pressure values at the nodes
+	 * @param l The Moordyn line
+	 * @param p Pressure values, and array with MoorDyn_GetLineN() + 1
+	 * values
+	 * @return MOORDYN_INVALID_VALUE if a NULL line is provided, MOORDYN_SUCCESS
+	 * otherwise
+	 * @see MoorDyn_IsLinePressBend()
+	 * @see MoorDyn_SetLinePressBend()
+	 */
+	int DECLDIR MoorDyn_SetLinePressInt(MoorDynLine l, const double* p);
+
 	/** @brief Get a line node position
 	 * @param l The Moordyn line
 	 * @param i The node index

--- a/source/Line.hpp
+++ b/source/Line.hpp
@@ -189,7 +189,11 @@ class Line final : public io::IO
 	std::vector<moordyn::real> dampYs;
 
 	// Externally provided data
-	/// Internal pipe pressure at the nodes (Pa)
+	/** true if pressure bending forces shall be considered, false otherwise
+	 * @see https://cds.cern.ch/record/1224245/files/PH-EP-Tech-Note-2009-004.pdf?version=1
+	 */
+	bool isPb;
+	/// internal pipe pressure at the nodes (Pa)
 	std::vector<moordyn::real> pin;
 
 	// kinematics
@@ -199,6 +203,8 @@ class Line final : public io::IO
 	std::vector<vec> rd;
 	/// unit tangent vectors for each node
 	std::vector<vec> q;
+	/// unit normal vectors for each node (used in bending calcs)
+	std::vector<vec> pvec;
 	/// unit tangent vectors for each segment (used in bending calcs)
 	std::vector<vec> qs;
 	/// unstretched line segment lengths
@@ -222,6 +228,8 @@ class Line final : public io::IO
 	std::vector<vec> Td;
 	/// bending stiffness forces
 	std::vector<vec> Bs;
+	/// Pressure bending forces
+	std::vector<vec> Pb;
 	/// node weights
 	std::vector<vec> W;
 	/// node drag (transversal)
@@ -763,6 +771,37 @@ class Line final : public io::IO
 		Cdn = Cdn * scaler;
 		Cdt = Cdt * scaler;
 	}
+
+	/** @brief Enable the pressure bending forces (disabled by default)
+	 *
+	 * The internal pressure can be provided at each node by calling
+	 * ::internalPress(), while the external pressure is computed as the
+	 * hydrostatic pressure plus the dynamic pressure (see
+	 * moordyn::Waves::getWaveKinLine()).
+	 *
+	 * If no internal pressure is provided, zeros will be considered.
+	 */
+	inline void enablePb() { isPb = true; }
+
+	/** @brief Disable the pressure bending forces (disabled by default)
+	 */
+	inline void disablePb() { isPb = false; }
+
+	/** @brief Check if pressure bending forces are considered
+	 * @return true if pressure bending forces are considered, false otherwise
+	 */
+	inline bool enabledPb() const { return isPb; }
+
+	/** @brief Set the internal pressure at each node of the line
+	 *
+	 * If this is not provided, the last stored values (zero by default) will
+	 * be considered.
+	 *
+	 * This function is useless unless ::enablePb() is called.
+	 * @param p The pressure values (Pa) at each node
+	 * @throws invalid_value_error If @p p has wrong size
+	 */
+	void setPin(std::vector<real> p);
 
 	/** @brief Set the line  simulation time
 	 * @param time Simulation time

--- a/source/Line.hpp
+++ b/source/Line.hpp
@@ -188,6 +188,10 @@ class Line final : public io::IO
 	/// y array for stress-strainrate lookup table
 	std::vector<moordyn::real> dampYs;
 
+	// Externally provided data
+	/// Internal pipe pressure at the nodes (Pa)
+	std::vector<moordyn::real> pin;
+
 	// kinematics
 	/// node positions
 	std::vector<vec> r;

--- a/source/Misc.cpp
+++ b/source/Misc.cpp
@@ -331,14 +331,21 @@ orientationAngles(vec v)
 moordyn::real
 GetCurvature(moordyn::real length, const vec& q1, const vec& q2)
 {
+	// There are several ways to compute the discrete curvature. See for
+	// instance the notes on
+	// https://www.cs.utexas.edu/users/evouga/uploads/4/5/6/8/45689883/notes1.pdf
+	// Here the expression k = 4 / l * sin(phi/2) is considered, with the
+	// following trigonometric identity:
+	// cos(phi) = q1.q2 = 1 - 2 sin^2(phi/2)
+
 	// note "length" here is combined from both segments
 
-	auto q1_dot_q2 = q1.dot(q2);
+	const auto q1_dot_q2 = q1.dot(q2);
 
-	if (q1_dot_q2 >
-	    1.0) // this is just a small numerical error, so set q1_dot_q2 to 1
-		return 0.0; // this occurs when there's no curvature, so return zero
-		            // curvature
+	if (q1_dot_q2 + std::numeric_limits<moordyn::real>::epsilon() > 1.0) {
+		// this occurs when there's no curvature, so return zero curvature
+		return 0.0;
+	}
 
 	// else if (q1_dot_q2 < 0)   // this is a bend of more than 90 degrees, too
 	// much, call an error! {	 //<<< maybe throwing an error is overkill,

--- a/source/Misc.hpp
+++ b/source/Misc.hpp
@@ -1036,6 +1036,10 @@ typedef struct _FailProps
 const int nCoef = 30; // maximum number of entries to allow in nonlinear
                       // coefficient lookup tables
 
+/** \ingroup environment
+ *  @{
+ */
+
 struct EnvCond
 {
 	/// Gavity acceleration (m/s^2)
@@ -1071,6 +1075,8 @@ struct EnvCond
 };
 
 typedef std::shared_ptr<EnvCond> EnvCondRef;
+
+/// @}
 
 typedef struct _LineProps // (matching Line Dictionary inputs)
 {

--- a/source/Point.cpp
+++ b/source/Point.cpp
@@ -348,7 +348,7 @@ Point::doRHS()
 	// --------------------------------- apply wave kinematics
 	// ------------------------------------
 
-	auto [zeta, U, Ud] = waves->getWaveKinPoint(pointId);
+	auto [zeta, U, Ud, Pdyn] = waves->getWaveKinPoint(pointId);
 	// env->waves->getU(r, t, U); // call generic function to get water
 	// velocities  <<<<<<<<<<<<<<<< all needs updating
 

--- a/source/Waves.hpp
+++ b/source/Waves.hpp
@@ -464,13 +464,13 @@ class Waves : public LogUser
 
 	using NodeKinReturnType = std::tuple<const std::vector<real>&,
 	                                     const std::vector<vec3>&,
-	                                     const std::vector<vec3>&>;
+	                                     const std::vector<vec3>&,
+	                                     const std::vector<real>&>;
 	/**
 	 * @brief Get the water kinematics for the line with id
 	 *
 	 * @param lineId Id of the line
-	 * @return std::tuple<std::vector<real>, std::vector<vec3>&,
-	 * std::vector<vec3>&> (zeta, U, Ud)
+	 * @return NodeKinReturnType (zeta, U, Ud, pDyn)
 	 */
 	NodeKinReturnType getWaveKinLine(size_t lineId);
 
@@ -478,16 +478,9 @@ class Waves : public LogUser
 	 * @brief Get the water kinematics for the rod with given Id.
 	 *
 	 * @param rodId Id of the rod
-	 * @return std::tuple<const std::vector<real>&,
-	 * const std::vector<vec3>&,
-	 * const std::vector<vec3>&,
-	 * const std::vector<real>&>  (zeta, U, Ud, pDyn)
+	 * @return NodeKinReturnType (zeta, U, Ud, pDyn)
 	 */
-	std::tuple<const std::vector<real>&,
-	           const std::vector<vec3>&,
-	           const std::vector<vec3>&,
-	           const std::vector<real>&>
-	getWaveKinRod(size_t rodId);
+	NodeKinReturnType getWaveKinRod(size_t rodId);
 
 	/**
 	 * @brief Get the water kinematics for the body with given Id
@@ -495,7 +488,7 @@ class Waves : public LogUser
 	 * The vectors should all be of length 1
 	 *
 	 * @param bodyId Id of the body
-	 * @return NodeKinReturnType (zeta, U, Ud)
+	 * @return NodeKinReturnType (zeta, U, Ud, pDyn)
 	 */
 	NodeKinReturnType getWaveKinBody(size_t bodyId);
 
@@ -505,7 +498,7 @@ class Waves : public LogUser
 	 * The vectors should all be of length 1
 	 *
 	 * @param pointId Id of the points
-	 * @return NodeKinReturnType (zeta, U, Ud)
+	 * @return NodeKinReturnType (zeta, U, Ud, pDyn)
 	 */
 	NodeKinReturnType getWaveKinPoint(size_t pointId);
 
@@ -552,11 +545,12 @@ class Waves : public LogUser
 		std::vector<std::vector<real>> zetas;
 		std::vector<std::vector<vec3>> U;
 		std::vector<std::vector<vec3>> Ud;
+		std::vector<std::vector<real>> Pdyn;
 
 		NodeKinReturnType operator[](size_t idx)
 		{
 
-			return { zetas[idx], U[idx], Ud[idx] };
+			return { zetas[idx], U[idx], Ud[idx], Pdyn[idx] };
 		}
 	};
 
@@ -571,10 +565,6 @@ class Waves : public LogUser
 		NodeKinematics<moordyn::Line> lines;
 		NodeKinematics<moordyn::Body> bodies;
 		NodeKinematics<moordyn::Rod> rods;
-		// at the moment, only rods need dynamic pressure
-		// so this kind of lives on its own
-		std::vector<std::vector<real>> rodPdyn;
-
 		NodeKinematics<moordyn::Point> points;
 	};
 
@@ -600,6 +590,7 @@ class Waves : public LogUser
 		nodeKinematics.zetas.emplace_back(num_nodes, 0.0);
 		nodeKinematics.U.emplace_back(num_nodes, vec3::Zero());
 		nodeKinematics.Ud.emplace_back(num_nodes, vec3::Zero());
+		nodeKinematics.Pdyn.emplace_back(num_nodes, 0.0);
 	}
 
 	/**

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,7 +26,6 @@ set(CPP_TESTS
     minimal
     lifting
     pendulum
-    beam
     time_schemes
     io
     rods
@@ -43,6 +42,8 @@ set(CPP_TESTS
 set(CATCH2_TESTS 
     math_tests
     testDecomposeString
+    beam
+    conveying_fluid
     polyester
 )
 

--- a/tests/conveying_fluid.cpp
+++ b/tests/conveying_fluid.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2022 Jose Luis Cercos-Pita <jlc@core-marine.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/** @file conveying_fluid.cpp
+ * It is just a demo on adding a constant internal pressure and its effect
+ * further buckling the pipe.
+ */
+
+#include "MoorDyn2.h"
+#define _USE_MATH_DEFINES
+#include <math.h>
+#include <iostream>
+#include <catch2/catch_test_macros.hpp>
+
+#define Z0 10.0
+#define L 10.0
+#define D 0.05
+#define W 100.0
+#define EA 1.5e9
+#define EI 1.0e7
+#define G 9.80665
+// Curvature estimated from the analytic solution
+#define K 0.00122
+
+using namespace std;
+
+/** @brief Simply supported beam analytic solution
+ * @param x x position of the node
+ * @return z position of the node
+ * @see
+ * https://www.efunda.com/formulae/solid_mechanics/beams/casestudy_display.cfm?case=simple_uniformload
+ */
+double
+simply_supported_solution(double x)
+{
+	const double p = W * G;
+	return -p * x * (L * L * L - 2. * x * x * L + x * x * x) / (24. * EI);
+}
+
+TEST_CASE("Pipe buckling while conveying fluid")
+{
+	MoorDyn system = MoorDyn_Create("Mooring/BeamSimplySupported.txt");
+	REQUIRE(system);
+
+	auto line = MoorDyn_GetLine(system, 1);
+	REQUIRE(line);
+	unsigned int n_nodes;
+	REQUIRE(MoorDyn_GetLineNumberNodes(line, &n_nodes) == MOORDYN_SUCCESS);
+	double* pin = (double*)malloc(n_nodes * sizeof(double));
+	REQUIRE(pin);
+	// Set a press force of about 1% of the beam weight
+	const double A = 0.25 * M_PI * D * D;
+	const double P = 1.e-2 * W * G / (A * K);
+	for (unsigned int i = 0; i < n_nodes; i++)
+		pin[i] = P;
+	REQUIRE(MoorDyn_SetLinePressBend(line, 1) == MOORDYN_SUCCESS);
+	REQUIRE(MoorDyn_SetLinePressInt(line, pin) == MOORDYN_SUCCESS);
+
+	REQUIRE(MoorDyn_Init(system, NULL, NULL) == MOORDYN_SUCCESS);
+
+	// Compare the node positions
+	for (unsigned int i = 1; i < n_nodes - 1; i++) {
+		double pos[3];
+		REQUIRE(MoorDyn_GetLineNodePos(line, i, pos) == MOORDYN_SUCCESS);
+		const double z = simply_supported_solution(pos[0]);
+		REQUIRE((pos[2] - Z0) < z);
+	}
+
+	REQUIRE(MoorDyn_Close(system) == MOORDYN_SUCCESS);
+}

--- a/wrappers/fortran/MoorDyn.f90
+++ b/wrappers/fortran/MoorDyn.f90
@@ -38,12 +38,12 @@ module moordyn
              MoorDyn_GetRodNodeVel, MoorDyn_SaveRodVTK, &
              MoorDyn_GetPointPos, MoorDyn_GetPointVel, &
              MoorDyn_GetPointForce, MoorDyn_GetPointM, MoorDyn_SavePointVTK, &
-             MoorDyn_GetLineNodePos, MoorDyn_GetLineNodeVel, &
-             MoorDyn_GetLineNodeForce, MoorDyn_GetLineNodeTen, &
-             MoorDyn_GetLineNodeBendStiff, MoorDyn_GetLineNodeWeight, &
-             MoorDyn_GetLineNodeDrag, MoorDyn_GetLineNodeFroudeKrilov, &
-             MoorDyn_GetLineNodeSeabedForce, MoorDyn_GetLineNodeM, &
-             MoorDyn_SaveLineVTK
+             MoorDyn_SetLinePressInt, MoorDyn_GetLineNodePos, &
+             MoorDyn_GetLineNodeVel, MoorDyn_GetLineNodeForce, &
+             MoorDyn_GetLineNodeTen, MoorDyn_GetLineNodeBendStiff, &
+             MoorDyn_GetLineNodeWeight, MoorDyn_GetLineNodeDrag, &
+             MoorDyn_GetLineNodeFroudeKrilov, MoorDyn_GetLineNodeSeabedForce, &
+             MoorDyn_GetLineNodeM, MoorDyn_SaveLineVTK
 
   public :: MD_Create, MD_NCoupledDOF, MD_SetVerbosity, MD_SetLogFile, &
             MD_SetLogLevel, MD_Log, MD_Init, MD_Init_NoIC, MD_Step, MD_Close, &
@@ -67,9 +67,10 @@ module moordyn
             MD_GetLineID, MD_GetLineN, MD_GetLineNumberNodes, &
             MD_GetLineUnstretchedLength, MD_SetLineUnstretchedLength, &
             MD_SetLineUnstretchedLengthVel, MD_IsLineConstantEA, &
-            MD_GetLineConstantEA, MD_SetLineConstantEA, MD_GetLineNodePos, &
-            MD_GetLineNodeVel, MD_GetLineNodeForce, MD_GetLineNodeTen, &
-            MD_GetLineNodeBendStiff, MD_GetLineNodeWeight, &
+            MD_GetLineConstantEA, MD_SetLineConstantEA, &
+            MD_IsLinePressBend, MD_SetLinePressBend, MD_SetLinePressInt, &
+            MD_GetLineNodePos, MD_GetLineNodeVel, MD_GetLineNodeForce, &
+            MD_GetLineNodeTen, MD_GetLineNodeBendStiff, MD_GetLineNodeWeight, &
             MD_GetLineNodeDrag, MD_GetLineNodeFroudeKrilov, &
             MD_GetLineNodeSeabedForce, MD_GetLineNodeCurv, &
             MD_GetLineNodeM, MD_GetLineMaxTen, MD_GetLineFairTen, &
@@ -556,6 +557,25 @@ module moordyn
       real(c_double), intent(out) :: ea
     end function MD_SetLineConstantEA
 
+    integer(c_int) function MD_IsLinePressBend(instance, t) bind(c, name='MoorDyn_IsLinePressBend')
+      import :: c_ptr, c_int
+      type(c_ptr), value, intent(in) :: instance
+      integer(c_int), intent(out) :: t
+    end function MD_IsLinePressBend
+
+    integer(c_int) function MD_SetLinePressBend(instance, b) bind(c, name='MoorDyn_SetLinePressBend')
+      import :: c_ptr, c_int
+      type(c_ptr), value, intent(in) :: instance
+      integer(c_int), intent(out) :: b
+    end function MD_SetLinePressBend
+
+    function MoorDyn_SetLinePressInt(instance, p) bind(c, name='MoorDyn_SetLinePressInt') result(rc)
+      import :: c_ptr, c_int
+      type(c_ptr), value, intent(in) :: instance
+      type(c_ptr), value, intent(in) :: p
+      integer(c_int) :: rc
+    end function MoorDyn_SetLinePressInt
+
     integer(c_int) function MD_GetLineUnstretchedLength(instance, l) bind(c, name='MoorDyn_GetLineUnstretchedLength')
       import :: c_ptr, c_double, c_int
       type(c_ptr), value, intent(in) :: instance
@@ -948,6 +968,13 @@ contains
 
   !                                Line.h
   ! ============================================================================
+
+  integer function MD_SetLinePressInt(instance, p)
+    use iso_c_binding
+    type(c_ptr), intent(in) :: instance
+    real(c_double), intent(in), target :: p(:)
+    MD_SetLinePressInt = MoorDyn_SetLinePressInt(instance, c_loc(p))
+  end function MD_SetLinePressInt
 
   integer function MD_GetLineNodePos(instance, n, r)
     use iso_c_binding

--- a/wrappers/matlab/MoorDynM_IsLinePressBend.cpp
+++ b/wrappers/matlab/MoorDynM_IsLinePressBend.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022, Matt Hall
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "mex.hpp"
+#include "mexAdapter.hpp"
+
+#include "MoorDyn2.h"
+#include "moordyn_matlab.h"
+
+using namespace matlab::data;
+using matlab::mex::ArgumentList;
+
+MOORDYNM_MEX_FUNCTION_BEGIN(MoorDynLine, 1, 1)
+{
+	int b;
+	const int err = MoorDyn_IsLinePressBend(instance, &b);
+	MOORDYNM_CHECK_ERROR(err);
+	outputs[0] = factory.createScalar<int>(b);
+}
+MOORDYNM_MEX_FUNCTION_END

--- a/wrappers/matlab/MoorDynM_SetLinePressBend.cpp
+++ b/wrappers/matlab/MoorDynM_SetLinePressBend.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022, Matt Hall
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "mex.hpp"
+#include "mexAdapter.hpp"
+
+#include "MoorDyn2.h"
+#include "moordyn_matlab.h"
+
+using namespace matlab::data;
+using matlab::mex::ArgumentList;
+
+MOORDYNM_MEX_FUNCTION_BEGIN(MoorDynLine, 2, 0)
+{
+	const int b = inputs[1][0];
+	const int err = MoorDyn_SetLinePressBend(instance, b);
+	MOORDYNM_CHECK_ERROR(err);
+}
+MOORDYNM_MEX_FUNCTION_END

--- a/wrappers/matlab/MoorDynM_SetLinePressInt.cpp
+++ b/wrappers/matlab/MoorDynM_SetLinePressInt.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022, Matt Hall
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "mex.hpp"
+#include "mexAdapter.hpp"
+
+#include "MoorDyn2.h"
+#include "moordyn_matlab.h"
+
+using namespace matlab::data;
+using matlab::mex::ArgumentList;
+
+MOORDYNM_MEX_FUNCTION_BEGIN(MoorDynLine, 2, 0)
+{
+	TypedArray<double> p_matlab = std::move(inputs[1]);
+	std::vector<double> p(p_matlab.begin(), p_matlab.end());
+	const int err = MoorDyn_SetLinePressInt(instance, p.data());
+	MOORDYNM_CHECK_ERROR(err);
+}
+MOORDYNM_MEX_FUNCTION_END

--- a/wrappers/python/moordyn/moordyn.py
+++ b/wrappers/python/moordyn/moordyn.py
@@ -1130,10 +1130,48 @@ def SetLineConstantEA(instance, ea):
     
     Parameters:
     instance (cmoordyn.MoorDynLine): The line instance
-    EA (float): The constant stiffness EA value
+    ea (float): The constant stiffness EA value
     """
     import cmoordyn
-    return cmoordyn.line_set_const_ea(instance, EA)
+    return cmoordyn.line_set_const_ea(instance, ea)
+
+
+def IsLinePressBend(instance):
+    """ Get whether the line pressure bending is considered or not
+    
+    Parameters:
+    instance (cmoordyn.MoorDynLine): The line instance
+
+    Returns:
+    b: True if the pressure bending of the line is enabled, False otherwise
+    """
+    import cmoordyn
+    return cmoordyn.line_is_pbend(b)
+
+
+def SetLinePressBend(instance, b):
+    """ Set whether the line pressure bending is considered or not
+    
+    This value is useless if non-linear stiffness is considered
+    
+    Parameters:
+    instance (cmoordyn.MoorDynLine): The line instance
+    b (bool): True if the pressure bending of the line shall be considered,
+              False otherwise
+    """
+    import cmoordyn
+    return cmoordyn.line_set_pbend(instance, b)
+
+
+def SetLinePressInt(instance, p):
+    """Set the line internal pressure values at the nodes
+
+    Parameters:
+    instance (cmoordyn.MoorDyn): The MoorDyn instance
+    p (list): Pressure values
+    """
+    import cmoordyn
+    return cmoordyn.line_set_pint(instance, list(p))
 
 
 def GetLineNodePos(instance, i):


### PR DESCRIPTION
This effect would be important for pipes, like risers, due to both the external pressure and the internal flow.

Some notes:

 - It is disable by default, so it is harmless.
 - It is not controllable from the config file, just from the API.
 - To enable it the C API function MoorDyn_SetLinePressBend() shall be called
 - Internal flow pressure can be set with the C API entry MoorDyn_SetLinePressInt()
 - ~The wrappers are not ready yet. I hope I will have them ready today or tomorrow~
