### PR TITLE
Fixed rod hydrostatics bug

### DIFF
--- a/source/Rod.hpp
+++ b/source/Rod.hpp
@@ -192,7 +192,7 @@ class Rod final : public io::IO, public SuperCFL
 
 	// wave things
 	/// VOF scalar for each segment (1 = fully submerged, 0 = out of water)
-	std::vector<moordyn::real> VOF;
+	std::vector<moordyn::real> VOF; // TODO: This doesnt need to be a vector, can be a double reused for each node
 	/// instantaneous axial submerged length [m]
 	real h0;
 


### PR DESCRIPTION
Changed the rod submergence code to match what is in MD-F, which has been verified with other codes. The submergence scalar, VOF0, was being incorrectly calculating causing rods to have less buoyancy than they should. Both MD-F and MD-C now match on the heave decay test for the case in #236. 

Resolves #236 
