### PR TITLE
Better Python wrappers

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -13,8 +13,8 @@ env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
   VTK_VERSION_MAJOR: 9
-  VTK_VERSION_MINOR: 2
-  VTK_VERSION_PATCH: 6
+  VTK_VERSION_MINOR: 3
+  VTK_VERSION_PATCH: 1
 
 jobs:
   create_release:

--- a/.github/workflows/python-wheels-emulated.yml
+++ b/.github/workflows/python-wheels-emulated.yml
@@ -24,7 +24,7 @@ jobs:
         os: ${{ fromJSON(inputs.os) }}
     env:
       # Skip 32-bit windows wheels builds.
-      CIBW_SKIP: "*-win32* pp38* pp39* pp310*"
+      CIBW_SKIP: "*-win32*"
       CIBW_ARCHS: ${{inputs.arch}}
       CIBW_ENVIRONMENT_LINUX: "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/project/install/lib"
       CIBW_BEFORE_ALL_LINUX: >

--- a/.github/workflows/python-wheels-emulated.yml
+++ b/.github/workflows/python-wheels-emulated.yml
@@ -63,9 +63,6 @@ jobs:
         rm -rf docs extern source tests
       CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair --add-path install/bin -w {dest_dir} {wheel}"
       CIBW_BEFORE_ALL_MACOS: >
-        echo "Considering vtk-macOS_`uname -m`.tar.gz..." &&
-        mkdir -p vtk &&
-        tar -xvzf vtk-macOS_`uname -m`.tar.gz -C vtk/ &&
         cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install -DEXTERNAL_EIGEN:BOOL=OFF -DPYTHON_WRAPPER:BOOL=OFF -DFORTRAN_WRAPPER:BOOL=OFF -DRUST_WRAPPER:BOOL=OFF -DUSE_VTK=ON -DVTK_DIR=vtk/lib/cmake/vtk-${{inputs.vtk_major}}.${{inputs.vtk_minor}} -DMOORDYN_PACKAGE_IGNORE_VTK_DEPENDENCY=ON -DBUILD_TESTING=OFF -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 -DCMAKE_INSTALL_NAME_DIR:PATH=$(pwd)/install/lib &&
         cmake --build build --config Release &&
         cmake --install build --config Release &&
@@ -119,6 +116,11 @@ jobs:
         run: |
             tar -xvzf vtk-Windows-x86_64.tar.gz -C vtk/
         if: runner.os == 'Windows'
+
+      - name: Extract VTK tgz (MacOS)
+        run: |
+            tar -xvzf vtk-macOS_${{inputs.arch}}.tar.gz -C vtk/
+        if: runner.os == 'MacOS'
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/python-wheels-emulated.yml
+++ b/.github/workflows/python-wheels-emulated.yml
@@ -39,7 +39,7 @@ jobs:
         os: ${{ fromJSON(inputs.os) }}
     env:
       # Skip 32-bit windows wheels builds.
-      CIBW_SKIP: "*-win32*"
+      CIBW_SKIP: "*-win32* pp38-* pp39-* pp310-*"
       CIBW_ARCHS: ${{inputs.arch}}
       CIBW_ENVIRONMENT_LINUX: "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/project/install/lib"
       CIBW_BEFORE_ALL_LINUX: >

--- a/.github/workflows/python-wheels-emulated.yml
+++ b/.github/workflows/python-wheels-emulated.yml
@@ -39,13 +39,18 @@ jobs:
         os: ${{ fromJSON(inputs.os) }}
     env:
       # Skip 32-bit windows wheels builds.
-      CIBW_SKIP: "*-win32* pp38-* pp39-* pp310-* *musllinux*ppc64le*"
+      CIBW_SKIP: "*-win32* pp38-* pp39-* pp310-*"
       CIBW_ARCHS: ${{inputs.arch}}
       CIBW_ENVIRONMENT_LINUX: "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/project/install/lib"
       CIBW_BEFORE_ALL_LINUX: >
-        echo "Considering vtk-manylinux2014_`uname -m`.tar.gz..." &&
+        if pip debug --verbose | grep -q 'musllinux'; then
+            DISTRO=musllinux_1_2
+        else
+            DISTRO=manylinux2014
+        fi &&
+        echo "Considering vtk-${DISTRO}_`uname -m`.tar.gz..." &&
         mkdir -p vtk &&
-        tar -xvzf vtk-manylinux2014_`uname -m`.tar.gz -C vtk/ &&
+        tar -xvzf vtk-${DISTRO}_`uname -m`.tar.gz -C vtk/ &&
         if [ -d "vtk/lib" ]; then
             VTK_DIR=vtk/lib/cmake/vtk-${{inputs.vtk_major}}.${{inputs.vtk_minor}}
         else
@@ -86,10 +91,17 @@ jobs:
             cat pyproject.toml
         shell: bash
 
-      - name: download pre-built VTK static library (Linux)
+      - name: download pre-built VTK static library (ManyLinux)
         uses: suisei-cn/actions-download-file@v1.6.0
         with:
           url: https://github.com/sanguinariojoe/vtk-builds/releases/download/VTK-${{inputs.vtk_major}}.${{inputs.vtk_minor}}.${{inputs.vtk_patch}}-static/vtk-manylinux2014_${{inputs.arch}}.tar.gz
+          target: ${{github.workspace}}/
+        if: runner.os == 'Linux'
+
+      - name: download pre-built VTK static library (MUSLLinux)
+        uses: suisei-cn/actions-download-file@v1.6.0
+        with:
+          url: https://github.com/sanguinariojoe/vtk-builds/releases/download/VTK-${{inputs.vtk_major}}.${{inputs.vtk_minor}}.${{inputs.vtk_patch}}-static/vtk-musllinux_1_2_${{inputs.arch}}.tar.gz
           target: ${{github.workspace}}/
         if: runner.os == 'Linux'
 

--- a/.github/workflows/python-wheels-emulated.yml
+++ b/.github/workflows/python-wheels-emulated.yml
@@ -39,7 +39,7 @@ jobs:
         os: ${{ fromJSON(inputs.os) }}
     env:
       # Skip 32-bit windows wheels builds.
-      CIBW_SKIP: "*-win32* pp38-* pp39-* pp310-*"
+      CIBW_SKIP: "*-win32* pp38-* pp39-* pp310-* *musllinux*ppc64le*"
       CIBW_ARCHS: ${{inputs.arch}}
       CIBW_ENVIRONMENT_LINUX: "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/project/install/lib"
       CIBW_BEFORE_ALL_LINUX: >

--- a/.github/workflows/python-wheels-emulated.yml
+++ b/.github/workflows/python-wheels-emulated.yml
@@ -102,7 +102,7 @@ jobs:
       - name: download pre-built VTK static library (MacOS)
         uses: suisei-cn/actions-download-file@v1.6.0
         with:
-          url: https://github.com/sanguinariojoe/vtk-builds/releases/download/VTK-${{inputs.vtk_major}}.${{inputs.vtk_minor}}.${{inputs.vtk_patch}}-static/vtk-macOS_${{inputs.arch}}.tar.gz
+          url: https://github.com/sanguinariojoe/vtk-builds/releases/download/VTK-${{inputs.vtk_major}}.${{inputs.vtk_minor}}.${{inputs.vtk_patch}}-static/vtk-macOS-${{inputs.arch}}.tar.gz
           target: ${{github.workspace}}/
         if: runner.os == 'MacOS'
 
@@ -119,7 +119,7 @@ jobs:
 
       - name: Extract VTK tgz (MacOS)
         run: |
-            tar -xvzf vtk-macOS_${{inputs.arch}}.tar.gz -C vtk/
+            tar -xvzf vtk-macOS-${{inputs.arch}}.tar.gz -C vtk/
         if: runner.os == 'MacOS'
 
       - name: Set up QEMU

--- a/.github/workflows/python-wheels-emulated.yml
+++ b/.github/workflows/python-wheels-emulated.yml
@@ -66,7 +66,7 @@ jobs:
         echo "Considering vtk-macOS_`uname -m`.tar.gz..." &&
         mkdir -p vtk &&
         tar -xvzf vtk-macOS_`uname -m`.tar.gz -C vtk/ &&
-        cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install -DEXTERNAL_EIGEN:BOOL=OFF -DPYTHON_WRAPPER:BOOL=OFF -DFORTRAN_WRAPPER:BOOL=OFF -DRUST_WRAPPER:BOOL=OFF -DUSE_VTK=ON -DVTK_DIR=vtk/lib/cmake/vtk-${{inputs.vtk_major}}.${{inputs.vtk_minor}} -DMOORDYN_PACKAGE_IGNORE_VTK_DEPENDENCY=ON -DBUILD_TESTING=OFF -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 &&
+        cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install -DEXTERNAL_EIGEN:BOOL=OFF -DPYTHON_WRAPPER:BOOL=OFF -DFORTRAN_WRAPPER:BOOL=OFF -DRUST_WRAPPER:BOOL=OFF -DUSE_VTK=ON -DVTK_DIR=vtk/lib/cmake/vtk-${{inputs.vtk_major}}.${{inputs.vtk_minor}} -DMOORDYN_PACKAGE_IGNORE_VTK_DEPENDENCY=ON -DBUILD_TESTING=OFF -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 -DCMAKE_INSTALL_NAME_DIR:PATH=$(pwd)/install/lib &&
         cmake --build build --config Release &&
         cmake --install build --config Release &&
         rm -rf docs extern source tests

--- a/.github/workflows/python-wheels-emulated.yml
+++ b/.github/workflows/python-wheels-emulated.yml
@@ -47,9 +47,9 @@ jobs:
         mkdir -p vtk &&
         tar -xvzf vtk-manylinux2014_`uname -m`.tar.gz -C vtk/ &&
         if [ -d "vtk/lib" ]; then
-            VTK_DIR=$(ls -d vtk/lib/cmake/vtk-*)
+            VTK_DIR=vtk/lib/cmake/vtk-${{inputs.vtk_major}}.${{inputs.vtk_minor}}
         else
-            VTK_DIR=$(ls -d vtk/lib64/cmake/vtk-*)
+            VTK_DIR=vtk/lib64/cmake/vtk-${{inputs.vtk_major}}.${{inputs.vtk_minor}}
         fi &&
         cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install -DEXTERNAL_EIGEN:BOOL=OFF -DPYTHON_WRAPPER:BOOL=OFF -DFORTRAN_WRAPPER:BOOL=OFF -DRUST_WRAPPER:BOOL=OFF -DUSE_VTK=ON -DVTK_DIR=$VTK_DIR -DMOORDYN_PACKAGE_IGNORE_VTK_DEPENDENCY=ON -DBUILD_TESTING=OFF &&
         cmake --build build --config Release &&
@@ -57,8 +57,7 @@ jobs:
         rm -rf docs extern source tests
       CIBW_BEFORE_BUILD_WINDOWS: "pip install delvewheel"
       CIBW_BEFORE_ALL_WINDOWS: >
-        VTK_DIR=$(ls -d vtk/lib/cmake/vtk-*) &&
-        cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install -DEXTERNAL_EIGEN:BOOL=OFF -DPYTHON_WRAPPER:BOOL=OFF -DFORTRAN_WRAPPER:BOOL=OFF -DRUST_WRAPPER:BOOL=OFF -DUSE_VTK=ON -DVTK_DIR=$VTK_DIR -DMOORDYN_PACKAGE_IGNORE_VTK_DEPENDENCY=ON -DBUILD_TESTING=OFF &&
+        cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install -DEXTERNAL_EIGEN:BOOL=OFF -DPYTHON_WRAPPER:BOOL=OFF -DFORTRAN_WRAPPER:BOOL=OFF -DRUST_WRAPPER:BOOL=OFF -DUSE_VTK=ON -DVTK_DIR=vtk/lib/cmake/vtk-${{inputs.vtk_major}}.${{inputs.vtk_minor}} -DMOORDYN_PACKAGE_IGNORE_VTK_DEPENDENCY=ON -DBUILD_TESTING=OFF &&
         cmake --build build --config Release &&
         cmake --install build --config Release &&
         rm -rf docs extern source tests

--- a/.github/workflows/python-wheels-emulated.yml
+++ b/.github/workflows/python-wheels-emulated.yml
@@ -24,7 +24,7 @@ jobs:
         os: ${{ fromJSON(inputs.os) }}
     env:
       # Skip 32-bit windows wheels builds.
-      CIBW_SKIP: "*-win32* *musllinux* pp38* pp39* pp310*"
+      CIBW_SKIP: "*-win32* pp38* pp39* pp310*"
       CIBW_ARCHS: ${{inputs.arch}}
       CIBW_ENVIRONMENT_LINUX: "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/project/install/lib"
       CIBW_BEFORE_ALL_LINUX: >

--- a/.github/workflows/python-wheels-emulated.yml
+++ b/.github/workflows/python-wheels-emulated.yml
@@ -63,7 +63,10 @@ jobs:
         rm -rf docs extern source tests
       CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair --add-path install/bin -w {dest_dir} {wheel}"
       CIBW_BEFORE_ALL_MACOS: >
-        cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install -DEXTERNAL_EIGEN:BOOL=OFF -DPYTHON_WRAPPER:BOOL=OFF -DFORTRAN_WRAPPER:BOOL=OFF -DRUST_WRAPPER:BOOL=OFF -DUSE_VTK=ON -DMOORDYN_PACKAGE_IGNORE_VTK_DEPENDENCY=OFF -DBUILD_TESTING=OFF -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 &&
+        echo "Considering vtk-macOS_`uname -m`.tar.gz..." &&
+        mkdir -p vtk &&
+        tar -xvzf vtk-macOS_`uname -m`.tar.gz -C vtk/ &&
+        cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install -DEXTERNAL_EIGEN:BOOL=OFF -DPYTHON_WRAPPER:BOOL=OFF -DFORTRAN_WRAPPER:BOOL=OFF -DRUST_WRAPPER:BOOL=OFF -DUSE_VTK=ON -DVTK_DIR=vtk/lib/cmake/vtk-${{inputs.vtk_major}}.${{inputs.vtk_minor}} -DMOORDYN_PACKAGE_IGNORE_VTK_DEPENDENCY=ON -DBUILD_TESTING=OFF -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 &&
         cmake --build build --config Release &&
         cmake --install build --config Release &&
         rm -rf docs extern source tests
@@ -99,9 +102,11 @@ jobs:
           target: ${{github.workspace}}/
         if: runner.os == 'Windows'
 
-      - name: Install VTK (MacOS)
-        run: |
-          brew install vtk
+      - name: download pre-built VTK static library (MacOS)
+        uses: suisei-cn/actions-download-file@v1.6.0
+        with:
+          url: https://github.com/sanguinariojoe/vtk-builds/releases/download/VTK-${{inputs.vtk_major}}.${{inputs.vtk_minor}}.${{inputs.vtk_patch}}-static/vtk-macOS_${{inputs.arch}}.tar.gz
+          target: ${{github.workspace}}/
         if: runner.os == 'MacOS'
 
       - name: Create folders

--- a/.github/workflows/python-wheels-emulated.yml
+++ b/.github/workflows/python-wheels-emulated.yml
@@ -12,6 +12,21 @@ on:
         description: 'Architecture target'
         required: true
         type: string
+      vtk_major:
+        description: 'VTK major version'
+        required: false
+        type: string
+        default: '9'
+      vtk_minor:
+        description: 'VTK minor version'
+        required: false
+        type: string
+        default: '3'
+      vtk_patch:
+        description: 'VTK patch version'
+        required: false
+        type: string
+        default: '1'
         
 permissions: write-all
 
@@ -32,9 +47,9 @@ jobs:
         mkdir -p vtk &&
         tar -xvzf vtk-manylinux2014_`uname -m`.tar.gz -C vtk/ &&
         if [ -d "vtk/lib" ]; then
-            VTK_DIR=vtk/lib/cmake/vtk-9.2/
+            VTK_DIR=$(ls -d vtk/lib/cmake/vtk-*)
         else
-            VTK_DIR=vtk/lib64/cmake/vtk-9.2/        
+            VTK_DIR=$(ls -d vtk/lib64/cmake/vtk-*)
         fi &&
         cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install -DEXTERNAL_EIGEN:BOOL=OFF -DPYTHON_WRAPPER:BOOL=OFF -DFORTRAN_WRAPPER:BOOL=OFF -DRUST_WRAPPER:BOOL=OFF -DUSE_VTK=ON -DVTK_DIR=$VTK_DIR -DMOORDYN_PACKAGE_IGNORE_VTK_DEPENDENCY=ON -DBUILD_TESTING=OFF &&
         cmake --build build --config Release &&
@@ -42,13 +57,14 @@ jobs:
         rm -rf docs extern source tests
       CIBW_BEFORE_BUILD_WINDOWS: "pip install delvewheel"
       CIBW_BEFORE_ALL_WINDOWS: >
-        cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install -DEXTERNAL_EIGEN:BOOL=OFF -DPYTHON_WRAPPER:BOOL=OFF -DFORTRAN_WRAPPER:BOOL=OFF -DRUST_WRAPPER:BOOL=OFF -DUSE_VTK=ON -DVTK_DIR=vtk/lib/cmake/vtk-9.2/ -DMOORDYN_PACKAGE_IGNORE_VTK_DEPENDENCY=ON -DBUILD_TESTING=OFF &&
+        VTK_DIR=$(ls -d vtk/lib/cmake/vtk-*) &&
+        cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install -DEXTERNAL_EIGEN:BOOL=OFF -DPYTHON_WRAPPER:BOOL=OFF -DFORTRAN_WRAPPER:BOOL=OFF -DRUST_WRAPPER:BOOL=OFF -DUSE_VTK=ON -DVTK_DIR=$VTK_DIR -DMOORDYN_PACKAGE_IGNORE_VTK_DEPENDENCY=ON -DBUILD_TESTING=OFF &&
         cmake --build build --config Release &&
         cmake --install build --config Release &&
         rm -rf docs extern source tests
       CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair --add-path install/bin -w {dest_dir} {wheel}"
       CIBW_BEFORE_ALL_MACOS: >
-        cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install -DEXTERNAL_EIGEN:BOOL=OFF -DPYTHON_WRAPPER:BOOL=OFF -DFORTRAN_WRAPPER:BOOL=OFF -DRUST_WRAPPER:BOOL=OFF -DUSE_VTK=ON -DMOORDYN_PACKAGE_IGNORE_VTK_DEPENDENCY=ON -DBUILD_TESTING=OFF -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 &&
+        cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install -DEXTERNAL_EIGEN:BOOL=OFF -DPYTHON_WRAPPER:BOOL=OFF -DFORTRAN_WRAPPER:BOOL=OFF -DRUST_WRAPPER:BOOL=OFF -DUSE_VTK=ON -DMOORDYN_PACKAGE_IGNORE_VTK_DEPENDENCY=OFF -DBUILD_TESTING=OFF -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 &&
         cmake --build build --config Release &&
         cmake --install build --config Release &&
         rm -rf docs extern source tests
@@ -73,14 +89,14 @@ jobs:
       - name: download pre-built VTK static library (Linux)
         uses: suisei-cn/actions-download-file@v1.6.0
         with:
-          url: https://github.com/sanguinariojoe/vtk-builds/releases/download/VTK-9.2.6-static/vtk-manylinux2014_${{inputs.arch}}.tar.gz
+          url: https://github.com/sanguinariojoe/vtk-builds/releases/download/VTK-${{inputs.vtk_major}}.${{inputs.vtk_minor}}.${{inputs.vtk_patch}}-static/vtk-manylinux2014_${{inputs.arch}}.tar.gz
           target: ${{github.workspace}}/
         if: runner.os == 'Linux'
 
       - name: download pre-built VTK static library (Windows)
         uses: suisei-cn/actions-download-file@v1.6.0
         with:
-          url: https://github.com/sanguinariojoe/vtk-builds/releases/download/VTK-9.2.6-static/vtk-Windows-x86_64.tar.gz
+          url: https://github.com/sanguinariojoe/vtk-builds/releases/download/VTK-${{inputs.vtk_major}}.${{inputs.vtk_minor}}.${{inputs.vtk_patch}}-static/vtk-Windows-x86_64.tar.gz
           target: ${{github.workspace}}/
         if: runner.os == 'Windows'
 

--- a/.github/workflows/python-wheels-emulated.yml
+++ b/.github/workflows/python-wheels-emulated.yml
@@ -62,6 +62,7 @@ jobs:
         cmake --install build --config Release &&
         rm -rf docs extern source tests
       CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair --add-path install/bin -w {dest_dir} {wheel}"
+      CIBW_ENVIRONMENT_MACOS: 'MACOSX_DEPLOYMENT_TARGET="10.15"'
       CIBW_BEFORE_ALL_MACOS: >
         cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install -DEXTERNAL_EIGEN:BOOL=OFF -DPYTHON_WRAPPER:BOOL=OFF -DFORTRAN_WRAPPER:BOOL=OFF -DRUST_WRAPPER:BOOL=OFF -DUSE_VTK=ON -DVTK_DIR=vtk/lib/cmake/vtk-${{inputs.vtk_major}}.${{inputs.vtk_minor}} -DMOORDYN_PACKAGE_IGNORE_VTK_DEPENDENCY=ON -DBUILD_TESTING=OFF -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 -DCMAKE_INSTALL_NAME_DIR:PATH=$(pwd)/install/lib &&
         cmake --build build --config Release &&

--- a/.github/workflows/python-wheels-test.yml
+++ b/.github/workflows/python-wheels-test.yml
@@ -42,7 +42,7 @@ jobs:
             cd dist/
             pip debug --verbose
             ls -alh
-            pip install $(ls *cp312*.whl) --break-system-packages
+            pip install $(ls *cp312*.whl -I "*musllinux*") --break-system-packages
             cd ../tests
             python test_minimal.py
         shell: bash

--- a/.github/workflows/python-wheels-test.yml
+++ b/.github/workflows/python-wheels-test.yml
@@ -40,9 +40,10 @@ jobs:
       - name: Install and run
         run: |
             cd dist/
+            rm -f *musllinux*.whl
             pip debug --verbose
             ls -alh
-            pip install $(ls *cp312*.whl -I "*musllinux*") --break-system-packages
+            pip install $(ls *cp312*.whl) --break-system-packages
             cd ../tests
             python test_minimal.py
         shell: bash

--- a/.github/workflows/python-wheels-test.yml
+++ b/.github/workflows/python-wheels-test.yml
@@ -1,0 +1,48 @@
+name: Python-manylinux-arch
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        description: 'Host OS'
+        required: false
+        type: string
+        default: '["ubuntu-22.04"]'
+      arch:
+        description: 'Architecture target'
+        required: true
+        type: string
+        
+permissions: write-all
+
+jobs:
+  test_wheels:
+    name: Test Python wheels
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ${{ fromJSON(inputs.os) }}
+      
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12' 
+
+      - name: Download the wheels
+        uses: actions/download-artifact@v4
+        with:
+          path: dist/
+          pattern: python-wheels-${{runner.os}}_${{inputs.arch}}*
+          merge-multiple: true
+
+      - name: Install and run
+        run: |
+            cd dist/
+            pip debug --verbose
+            ls -alh
+            pip install $(ls *cp312*.whl) --break-system-packages
+            cd ../tests
+            python test_minimal.py
+        shell: bash

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -142,7 +142,7 @@ jobs:
 
   publish:
     runs-on: ${{ matrix.os }}
-    needs: [build_wheels, build_Linux_x86_64, build_Windows_AMD64, build_MacOS_x86_64, build_Linux_i686, build_Linux_aarch64, build_Linux_ppc64le, build_Linux_s390x, test_Linux_x86_64, test_Windows_AMD64, test_MacOS_x86_64]
+    needs: [build_wheels, build_Linux_x86_64, build_Windows_AMD64, build_MacOS_x86_64, build_MacOS_arm64, build_Linux_i686, build_Linux_aarch64, build_Linux_ppc64le, build_Linux_s390x, test_Linux_x86_64, test_Windows_AMD64, test_MacOS_arm64]
     strategy:
         matrix:
             os: [ubuntu-22.04]

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -10,8 +10,8 @@ env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
   VTK_VERSION_MAJOR: 9
-  VTK_VERSION_MINOR: 2
-  VTK_VERSION_PATCH: 6
+  VTK_VERSION_MINOR: 3
+  VTK_VERSION_PATCH: 1
 
 jobs:
   build_wheels:

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -69,8 +69,16 @@ jobs:
     name: Build MacOS_x86_64
     uses: FloatingArrayDesign/MoorDyn/.github/workflows/python-wheels-emulated.yml@master
     with:
-      os: '["macOS-latest"]'
+      os: '["macOS-13"]'
       arch: "x86_64"
+    secrets: inherit
+
+  build_MacOS_arm64:
+    name: Build MacOS_arm64
+    uses: FloatingArrayDesign/MoorDyn/.github/workflows/python-wheels-emulated.yml@master
+    with:
+      os: '["macOS-14"]'
+      arch: "arm64"
     secrets: inherit
 
   build_Linux_i686:
@@ -105,9 +113,36 @@ jobs:
       arch: "s390x"
     secrets: inherit
 
+  test_Linux_x86_64:
+    name: Test Linux_x86_64
+    needs: [build_Linux_x86_64]
+    uses: FloatingArrayDesign/MoorDyn/.github/workflows/python-wheels-test.yml@master
+    with:
+      os: '["ubuntu-22.04"]'
+      arch: "x86_64"
+    secrets: inherit
+
+  test_Windows_AMD64:
+    name: Test Windows_AMD64
+    needs: [build_Windows_AMD64]
+    uses: FloatingArrayDesign/MoorDyn/.github/workflows/python-wheels-test.yml@master
+    with:
+      os: '["windows-latest"]'
+      arch: "AMD64"
+    secrets: inherit
+
+  test_MacOS_arm64:
+    name: Test MacOS_arm64
+    needs: [build_MacOS_arm64]
+    uses: FloatingArrayDesign/MoorDyn/.github/workflows/python-wheels-test.yml@master
+    with:
+      os: '["macOS-14"]'
+      arch: "arm64"
+    secrets: inherit
+
   publish:
     runs-on: ${{ matrix.os }}
-    needs: [build_wheels, build_Linux_x86_64, build_Windows_AMD64, build_MacOS_x86_64, build_Linux_i686, build_Linux_aarch64, build_Linux_ppc64le, build_Linux_s390x]
+    needs: [build_wheels, build_Linux_x86_64, build_Windows_AMD64, build_MacOS_x86_64, build_Linux_i686, build_Linux_aarch64, build_Linux_ppc64le, build_Linux_s390x, test_Linux_x86_64, test_Windows_AMD64, test_MacOS_x86_64]
     strategy:
         matrix:
             os: [ubuntu-22.04]

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -6,13 +6,6 @@ on:
 
 permissions: write-all
 
-env:
-  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-  BUILD_TYPE: Release
-  VTK_VERSION_MAJOR: 9
-  VTK_VERSION_MINOR: 3
-  VTK_VERSION_PATCH: 1
-
 jobs:
   build_wheels:
     name: Build Python wheels x86_64

--- a/.github/workflows/python-wrapper.yml
+++ b/.github/workflows/python-wrapper.yml
@@ -13,8 +13,8 @@ env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
   VTK_VERSION_MAJOR: 9
-  VTK_VERSION_MINOR: 2
-  VTK_VERSION_PATCH: 6
+  VTK_VERSION_MINOR: 3
+  VTK_VERSION_PATCH: 1
 
 jobs:
   test:


### PR DESCRIPTION
I fixed a lot of problems on the Python wrappers, and made them more flexible.

The next step is getting VTK linked dynamically instead of statically.

New supported architectures:

 - MacOS (>=10.15) arm64 (x86_64 was compiled, but I doubt it properly worked)
 - MUSLLinux
 
Lost architectures:

 - PyPy (>3.7)


