### PR TITLE
Missing API entries on the wrappers

### DIFF
--- a/wrappers/fortran/MoorDyn.f90
+++ b/wrappers/fortran/MoorDyn.f90
@@ -29,6 +29,8 @@ module moordyn
              MoorDyn_Init_NoIC, MoorDyn_Step, &
              MoorDyn_ExternalWaveKinGetCoordinates, &
              MoorDyn_ExternalWaveKinSet, MoorDyn_GetFASTtens, &
+             MoorDyn_GetDt, MoorDyn_GetCFL, &
+             MoorDyn_GetTimeScheme, MoorDyn_SetTimeScheme, &
              MoorDyn_SaveState, MoorDyn_LoadState, &
              MoorDyn_Save, MoorDyn_Load, MoorDyn_SaveVTK, &
              MoorDyn_GetWavesKin, &
@@ -53,6 +55,8 @@ module moordyn
             MD_ExternalWaveKinSet, MD_GetNumberBodies, MD_GetBody, &
             MD_GetNumberRods, MD_GetRod, MD_GetNumberPoints, MD_GetPoint, &
             MD_GetNumberLines, MD_GetLine, MD_GetFASTtens, &
+            MD_GetDt, MD_SetDt, MD_GetCFL, MD_SetCFL, &
+            MD_GetTimeScheme, MD_SetTimeScheme, &
             MD_SaveState, MD_LoadState, MD_Save, MD_Load, &
             MD_SaveVTK, &
             MD_GetWavesKin, &
@@ -250,6 +254,47 @@ module moordyn
       type(c_ptr), value, intent(in) :: avt
       integer(c_int) :: rc
     end function MoorDyn_GetFASTtens
+
+    function MoorDyn_GetDt(instance, dt) bind(c, name='MoorDyn_GetDt') result(rc)
+      import :: c_ptr, c_double, c_int
+      type(c_ptr), value, intent(in) :: instance
+      type(c_ptr), value, intent(in) :: dt
+      integer(c_int) :: rc
+    end function MoorDyn_GetDt
+
+    integer(c_int) function MD_SetDt(instance, dt) bind(c, name='MoorDyn_SetDt')
+      import :: c_ptr, c_double, c_int
+      type(c_ptr), value, intent(in) :: instance
+      real(c_double), value, intent(in) :: dt
+    end function MD_SetDt
+
+    function MoorDyn_GetCFL(instance, cfl) bind(c, name='MoorDyn_GetCFL') result(rc)
+      import :: c_ptr, c_double, c_int
+      type(c_ptr), value, intent(in) :: instance
+      type(c_ptr), value, intent(in) :: cfl
+      integer(c_int) :: rc
+    end function MoorDyn_GetCFL
+
+    integer(c_int) function MD_SetCFL(instance, cfl) bind(c, name='MoorDyn_SetCFL')
+      import :: c_ptr, c_double, c_int
+      type(c_ptr), value, intent(in) :: instance
+      real(c_double), value, intent(in) :: cfl
+    end function MD_SetCFL
+
+    function MoorDyn_GetTimeScheme(instance, name, name_len) bind(c, name='MoorDyn_GetTimeScheme') result(rc)
+      import :: c_ptr, c_char, c_int
+      type(c_ptr), value, intent(in) :: instance
+      character(kind=c_char), intent(out) :: name(*)
+      integer(c_int), intent(inout) :: name_len
+      integer(c_int) :: rc
+    end function MoorDyn_GetTimeScheme
+
+    function MoorDyn_SetTimeScheme(instance, name) bind(c, name='MoorDyn_SetTimeScheme') result(rc)
+      import :: c_ptr, c_char, c_int
+      type(c_ptr), value, intent(in) :: instance
+      character(kind=c_char), intent(in) :: name(*)
+      integer(c_int) :: rc
+    end function MoorDyn_SetTimeScheme
 
     function MoorDyn_SaveState(instance, f) bind(c, name='MoorDyn_SaveState') result(rc)
       import :: c_ptr, c_char, c_int
@@ -797,6 +842,39 @@ contains
     real(c_double), intent(in), target :: avt(:)
     MD_GetFASTtens = MoorDyn_GetFASTtens(instance, n, c_loc(fht), c_loc(fvt), c_loc(aht), c_loc(avt))
   end function MD_GetFASTtens
+
+  integer function MD_GetDt(instance, dt)
+    use iso_c_binding
+    type(c_ptr), intent(in) :: instance
+    real(c_double), intent(in), target :: dt(:)
+    MD_GetDt = MoorDyn_GetDt(instance, c_loc(dt))
+  end function MD_GetDt
+
+  integer function MD_GetCFL(instance, cfl)
+    use iso_c_binding
+    type(c_ptr), intent(in) :: instance
+    real(c_double), intent(in), target :: cfl(:)
+    MD_GetCFL = MoorDyn_GetCFL(instance, c_loc(cfl))
+  end function MD_GetCFL
+
+  integer function MD_GetTimeScheme(instance, name, name_len)
+    use iso_c_binding
+    type(c_ptr), intent(in) :: instance
+    character(len=*), intent(out) :: name
+    integer(c_int), intent(inout) :: name_len
+    character(:, kind=c_char), allocatable :: cname
+    integer(c_int) :: i
+    allocate(character(name_len + 1) :: cname)
+    MD_GetTimeScheme = MoorDyn_GetTimeScheme(instance, cname, name_len)
+    name = cname(1:name_len-1)
+  end function MD_GetTimeScheme
+
+  integer function MD_SetTimeScheme(instance, name)
+    use iso_c_binding
+    type(c_ptr), intent(in) :: instance
+    character(*), intent(in) :: name
+    MD_SetTimeScheme = MoorDyn_SetTimeScheme(instance, trim(name) // c_null_char)
+  end function MD_SetTimeScheme
 
   integer function MD_SaveState(instance, f)
     use iso_c_binding

--- a/wrappers/matlab/MoorDynM_Deserialize.cpp
+++ b/wrappers/matlab/MoorDynM_Deserialize.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022, Matt Hall
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "mex.hpp"
+#include "mexAdapter.hpp"
+
+#include "MoorDyn2.h"
+#include "moordyn_matlab.h"
+
+using namespace matlab::data;
+using matlab::mex::ArgumentList;
+
+MOORDYNM_MEX_FUNCTION_BEGIN(MoorDyn, 2, 0)
+{
+	TypedArray<uint64_t> v_matlab = std::move(inputs[1]);
+	std::vector<uint64_t> v(v_matlab.begin(), v_matlab.end());
+	const int err = MoorDyn_Deserialize(instance, v.data());
+	MOORDYNM_CHECK_ERROR(err);
+}
+MOORDYNM_MEX_FUNCTION_END

--- a/wrappers/matlab/MoorDynM_GetCFL.cpp
+++ b/wrappers/matlab/MoorDynM_GetCFL.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022, Matt Hall
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "mex.hpp"
+#include "mexAdapter.hpp"
+
+#include "MoorDyn2.h"
+#include "moordyn_matlab.h"
+
+using namespace matlab::data;
+using matlab::mex::ArgumentList;
+
+MOORDYNM_MEX_FUNCTION_BEGIN(MoorDyn, 1, 1)
+{
+	double cfl;
+	const int err = MoorDyn_GetCFL(instance, &cfl);
+	MOORDYNM_CHECK_ERROR(err);
+	outputs[0] = factory.createScalar<double>(cfl);
+}
+MOORDYNM_MEX_FUNCTION_END

--- a/wrappers/matlab/MoorDynM_GetDt.cpp
+++ b/wrappers/matlab/MoorDynM_GetDt.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022, Matt Hall
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "mex.hpp"
+#include "mexAdapter.hpp"
+
+#include "MoorDyn2.h"
+#include "moordyn_matlab.h"
+
+using namespace matlab::data;
+using matlab::mex::ArgumentList;
+
+MOORDYNM_MEX_FUNCTION_BEGIN(MoorDyn, 1, 1)
+{
+	double dt;
+	const int err = MoorDyn_GetDt(instance, &dt);
+	MOORDYNM_CHECK_ERROR(err);
+	outputs[0] = factory.createScalar<double>(dt);
+}
+MOORDYNM_MEX_FUNCTION_END

--- a/wrappers/matlab/MoorDynM_GetTimeScheme.cpp
+++ b/wrappers/matlab/MoorDynM_GetTimeScheme.cpp
@@ -39,11 +39,12 @@ using matlab::mex::ArgumentList;
 
 MOORDYNM_MEX_FUNCTION_BEGIN(MoorDyn, 1, 1)
 {
+	int err;
 	size_t name_len;
-	const int err = MoorDyn_GetTimeScheme(instance, NULL, &name_len);
+	int err = MoorDyn_GetTimeScheme(instance, NULL, &name_len);
 	MOORDYNM_CHECK_ERROR(err);
 	char* name = (char*)malloc(name_len * sizeof(char));
-	const int err = MoorDyn_GetTimeScheme(instance, name, NULL);
+	int err = MoorDyn_GetTimeScheme(instance, name, NULL);
 	MOORDYNM_CHECK_ERROR(err);
 	outputs[0] = factory.createCharArray(std::string(name));
 }

--- a/wrappers/matlab/MoorDynM_GetTimeScheme.cpp
+++ b/wrappers/matlab/MoorDynM_GetTimeScheme.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2022, Matt Hall
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "mex.hpp"
+#include "mexAdapter.hpp"
+
+#include "MoorDyn2.h"
+#include "moordyn_matlab.h"
+
+using namespace matlab::data;
+using matlab::mex::ArgumentList;
+
+MOORDYNM_MEX_FUNCTION_BEGIN(MoorDyn, 1, 1)
+{
+	size_t name_len;
+	const int err = MoorDyn_GetTimeScheme(instance, NULL, &name_len);
+	MOORDYNM_CHECK_ERROR(err);
+	char* name = (char*)malloc(name_len * sizeof(char));
+	const int err = MoorDyn_GetTimeScheme(instance, name, NULL);
+	MOORDYNM_CHECK_ERROR(err);
+	outputs[0] = factory.createCharArray(std::string(name));
+}
+MOORDYNM_MEX_FUNCTION_END

--- a/wrappers/matlab/MoorDynM_GetTimeScheme.cpp
+++ b/wrappers/matlab/MoorDynM_GetTimeScheme.cpp
@@ -41,10 +41,10 @@ MOORDYNM_MEX_FUNCTION_BEGIN(MoorDyn, 1, 1)
 {
 	int err;
 	size_t name_len;
-	int err = MoorDyn_GetTimeScheme(instance, NULL, &name_len);
+	err = MoorDyn_GetTimeScheme(instance, NULL, &name_len);
 	MOORDYNM_CHECK_ERROR(err);
 	char* name = (char*)malloc(name_len * sizeof(char));
-	int err = MoorDyn_GetTimeScheme(instance, name, NULL);
+	err = MoorDyn_GetTimeScheme(instance, name, NULL);
 	MOORDYNM_CHECK_ERROR(err);
 	outputs[0] = factory.createCharArray(std::string(name));
 }

--- a/wrappers/matlab/MoorDynM_Serialize.cpp
+++ b/wrappers/matlab/MoorDynM_Serialize.cpp
@@ -39,11 +39,12 @@ using matlab::mex::ArgumentList;
 
 MOORDYNM_MEX_FUNCTION_BEGIN(MoorDyn, 1, 1)
 {
+	int err;
 	size_t data_size;
-	const int err = MoorDyn_Serialize(instance, &data_size, NULL);
+	err = MoorDyn_Serialize(instance, &data_size, NULL);
 	MOORDYNM_CHECK_ERROR(err);
 	std::vector<uint64_t> v(data_size / sizeof(uint64_t), 0);
-	const int err = MoorDyn_Serialize(instance, NULL, v.data());
+	err = MoorDyn_Serialize(instance, NULL, v.data());
 	MOORDYNM_CHECK_ERROR(err);
 	outputs[0] = factory.createArray<uint64_t>(
 	    { 1, v.size() }, v.data(), v.data() + v.size());

--- a/wrappers/matlab/MoorDynM_Serialize.cpp
+++ b/wrappers/matlab/MoorDynM_Serialize.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2022, Matt Hall
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "mex.hpp"
+#include "mexAdapter.hpp"
+
+#include "MoorDyn2.h"
+#include "moordyn_matlab.h"
+
+using namespace matlab::data;
+using matlab::mex::ArgumentList;
+
+MOORDYNM_MEX_FUNCTION_BEGIN(MoorDyn, 1, 1)
+{
+	size_t data_size;
+	const int err = MoorDyn_Serialize(instance, &data_size, NULL);
+	MOORDYNM_CHECK_ERROR(err);
+	std::vector<uint64_t> v(data_size / sizeof(uint64_t), 0);
+	const int err = MoorDyn_Serialize(instance, NULL, v.data());
+	MOORDYNM_CHECK_ERROR(err);
+	outputs[0] = factory.createArray<uint64_t>(
+	    { 1, v.size() }, v.data(), v.data() + v.size());
+
+}
+MOORDYNM_MEX_FUNCTION_END

--- a/wrappers/matlab/MoorDynM_SetCFL.cpp
+++ b/wrappers/matlab/MoorDynM_SetCFL.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022, Matt Hall
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "mex.hpp"
+#include "mexAdapter.hpp"
+
+#include "MoorDyn2.h"
+#include "moordyn_matlab.h"
+
+using namespace matlab::data;
+using matlab::mex::ArgumentList;
+
+MOORDYNM_MEX_FUNCTION_BEGIN(MoorDyn, 2, 0)
+{
+	double cfl = inputs[1][0];
+	const int err = MoorDyn_SetCFL(instance, cfl);
+	MOORDYNM_CHECK_ERROR(err);
+}
+MOORDYNM_MEX_FUNCTION_END

--- a/wrappers/matlab/MoorDynM_SetDt.cpp
+++ b/wrappers/matlab/MoorDynM_SetDt.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022, Matt Hall
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "mex.hpp"
+#include "mexAdapter.hpp"
+
+#include "MoorDyn2.h"
+#include "moordyn_matlab.h"
+
+using namespace matlab::data;
+using matlab::mex::ArgumentList;
+
+MOORDYNM_MEX_FUNCTION_BEGIN(MoorDyn, 2, 0)
+{
+	double dt = inputs[1][0];
+	const int err = MoorDyn_SetDt(instance, dt);
+	MOORDYNM_CHECK_ERROR(err);
+}
+MOORDYNM_MEX_FUNCTION_END

--- a/wrappers/matlab/MoorDynM_SetTimeScheme.cpp
+++ b/wrappers/matlab/MoorDynM_SetTimeScheme.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022, Matt Hall
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "mex.hpp"
+#include "mexAdapter.hpp"
+
+#include "MoorDyn2.h"
+#include "moordyn_matlab.h"
+
+using namespace matlab::data;
+using matlab::mex::ArgumentList;
+
+MOORDYNM_MEX_FUNCTION_BEGIN(MoorDyn, 2, 0)
+{
+	const CharArray name_matlab = inputs[0];
+	std::string name(name_matlab.toAscii());
+	const int err = MoorDyn_SetTimeScheme(instance, name.c_str());
+	MOORDYNM_CHECK_ERROR(err);
+}
+MOORDYNM_MEX_FUNCTION_END

--- a/wrappers/python/cmoordyn.cpp
+++ b/wrappers/python/cmoordyn.cpp
@@ -999,7 +999,7 @@ get_tscheme(PyObject*, PyObject* args)
 		PyErr_SetString(PyExc_RuntimeError, "Failure allocating memory");
 		return NULL;
 	}
-	err = MoorDyn_GetTimeScheme(system, name_len, &name_len);
+	err = MoorDyn_GetTimeScheme(system, name, &name_len);
 	if (err != 0) {
 		PyErr_SetString(PyExc_RuntimeError, "MoorDyn reported an error");
 		return NULL;

--- a/wrappers/python/cmoordyn.cpp
+++ b/wrappers/python/cmoordyn.cpp
@@ -862,6 +862,179 @@ get_fast_tens(PyObject*, PyObject* args)
 	return lst;
 }
 
+/** @brief Wrapper to MoorDyn_GetDt() function
+ * @param args Python passed arguments
+ * @return The time step
+ */
+static PyObject*
+get_dt(PyObject*, PyObject* args)
+{
+	PyObject* capsule;
+
+	if (!PyArg_ParseTuple(args, "O", &capsule))
+		return NULL;
+
+	MoorDyn system =
+	    (MoorDyn)PyCapsule_GetPointer(capsule, moordyn_capsule_name);
+	if (!system)
+		return NULL;
+
+	int err;
+	double dt;
+	err = MoorDyn_GetDt(system, &dt);
+	if (err != 0) {
+		PyErr_SetString(PyExc_RuntimeError, "MoorDyn reported an error");
+		return NULL;
+	}
+	return PyFloat_FromDouble(dt);
+}
+
+/** @brief Wrapper to MoorDyn_SetDt() function
+ * @param args Python passed arguments
+ * @return None
+ */
+static PyObject*
+set_dt(PyObject*, PyObject* args)
+{
+	PyObject* capsule;
+	double dt;
+
+	if (!PyArg_ParseTuple(args, "Od", &capsule, &dt))
+		return NULL;
+
+	MoorDyn system =
+	    (MoorDyn)PyCapsule_GetPointer(capsule, moordyn_capsule_name);
+	if (!system)
+		return NULL;
+
+	const int err = MoorDyn_SetDt(system, dt);
+	if (err != 0) {
+		PyErr_SetString(PyExc_RuntimeError, "MoorDyn reported an error");
+		return NULL;
+	}
+	return Py_None;
+}
+
+/** @brief Wrapper to MoorDyn_GetCFL() function
+ * @param args Python passed arguments
+ * @return The time step
+ */
+static PyObject*
+get_cfl(PyObject*, PyObject* args)
+{
+	PyObject* capsule;
+
+	if (!PyArg_ParseTuple(args, "O", &capsule))
+		return NULL;
+
+	MoorDyn system =
+	    (MoorDyn)PyCapsule_GetPointer(capsule, moordyn_capsule_name);
+	if (!system)
+		return NULL;
+
+	int err;
+	double cfl;
+	err = MoorDyn_GetCFL(system, &cfl);
+	if (err != 0) {
+		PyErr_SetString(PyExc_RuntimeError, "MoorDyn reported an error");
+		return NULL;
+	}
+	return PyFloat_FromDouble(cfl);
+}
+
+/** @brief Wrapper to MoorDyn_SetCFL() function
+ * @param args Python passed arguments
+ * @return None
+ */
+static PyObject*
+set_cfl(PyObject*, PyObject* args)
+{
+	PyObject* capsule;
+	double cfl;
+
+	if (!PyArg_ParseTuple(args, "Od", &capsule, &cfl))
+		return NULL;
+
+	MoorDyn system =
+	    (MoorDyn)PyCapsule_GetPointer(capsule, moordyn_capsule_name);
+	if (!system)
+		return NULL;
+
+	const int err = MoorDyn_SetCFL(system, cfl);
+	if (err != 0) {
+		PyErr_SetString(PyExc_RuntimeError, "MoorDyn reported an error");
+		return NULL;
+	}
+	return Py_None;
+}
+
+/** @brief Wrapper to MoorDyn_GetTimeScheme() function
+ * @param args Python passed arguments
+ * @return The time step
+ */
+static PyObject*
+get_tscheme(PyObject*, PyObject* args)
+{
+	PyObject* capsule;
+
+	if (!PyArg_ParseTuple(args, "O", &capsule))
+		return NULL;
+
+	MoorDyn system =
+	    (MoorDyn)PyCapsule_GetPointer(capsule, moordyn_capsule_name);
+	if (!system)
+		return NULL;
+
+	// We need to know the length of the name first
+	int err;
+	size_t name_len;
+	err = MoorDyn_GetTimeScheme(system, NULL, &name_len);
+	if (err != 0) {
+		PyErr_SetString(PyExc_RuntimeError, "MoorDyn reported an error");
+		return NULL;
+	}
+	// So we can allocate the name and ask for it
+	char* name = (char*)malloc(name_len * sizeof(char));
+	if (!name) {
+		PyErr_SetString(PyExc_RuntimeError, "Failure allocating memory");
+		return NULL;
+	}
+	err = MoorDyn_GetTimeScheme(system, name_len, &name_len);
+	if (err != 0) {
+		PyErr_SetString(PyExc_RuntimeError, "MoorDyn reported an error");
+		return NULL;
+	}
+	PyObject* out = PyUnicode_FromString(name);
+	free(name);
+	return out;
+}
+
+/** @brief Wrapper to MoorDyn_SetTimeScheme() function
+ * @param args Python passed arguments
+ * @return None
+ */
+static PyObject*
+set_tscheme(PyObject*, PyObject* args)
+{
+	PyObject* capsule;
+	char* tscheme = NULL;
+
+	if (!PyArg_ParseTuple(args, "Os", &capsule, &tscheme))
+		return NULL;
+
+	MoorDyn system =
+	    (MoorDyn)PyCapsule_GetPointer(capsule, moordyn_capsule_name);
+	if (!system)
+		return NULL;
+
+	const int err = MoorDyn_SetTimeScheme(system, tscheme);
+	if (err != 0) {
+		PyErr_SetString(PyExc_RuntimeError, "MoorDyn reported an error");
+		return NULL;
+	}
+	return Py_None;
+}
+
 /** @brief Wrapper to MoorDyn_SaveState() function
  * @param args Python passed arguments
  * @return None
@@ -2860,6 +3033,12 @@ static PyMethodDef moordyn_methods[] = {
 	  get_fast_tens,
 	  METH_VARARGS,
 	  "Get vertical and horizontal forces in the mooring lines" },
+	{ "get_dt", get_dt, METH_VARARGS, "Get the inner time step" },
+	{ "set_dt", set_dt, METH_VARARGS, "Set the inner time step" },
+	{ "get_cfl", get_cfl, METH_VARARGS, "Get the CFL factor" },
+	{ "set_cfl", set_cfl, METH_VARARGS, "Set the CFL factor" },
+	{ "get_tscheme", get_tscheme, METH_VARARGS, "Get the time scheme" },
+	{ "set_tscheme", set_tscheme, METH_VARARGS, "Set the time scheme" },
 	{ "save_state", save_state, METH_VARARGS, "Save the system state" },
 	{ "load_state", load_state, METH_VARARGS, "Load the system state" },
 	{ "serialize",

--- a/wrappers/python/moordyn/moordyn.py
+++ b/wrappers/python/moordyn/moordyn.py
@@ -306,7 +306,7 @@ def ExternalWaveKinGetN(instance):
     return cmoordyn.ext_wave_init(instance)
 
 
-def GetWaveKinCoordinates(instance):
+def ExternalWaveKinGetCoordinates(instance):
     """Get the points where the waves kinematics shall be provided
 
     The kinematics on those points shall be provided just if WaveKin is set
@@ -328,7 +328,19 @@ def GetWaveKinCoordinates(instance):
     return points
 
 
-def SetWaveKin(instance, u, a, t):
+def GetWaveKinCoordinates(instance):
+    """Just an alias for moordyn.ExternalWaveKinGetCoordinates()
+
+    Parameters:
+    instance (cmoordyn.MoorDyn): The MoorDyn instance
+
+    Returns:
+    list (n, 3): The list of points
+    """
+    return ExternalWaveKinGetCoordinates(instance)
+
+
+def ExternalWaveKinSet(instance, u, a, t):
     """Set the kinematics of the waves
 
     Use this function if WaveKin option is set to 1 in the input file
@@ -353,6 +365,23 @@ def SetWaveKin(instance, u, a, t):
         uu += u[i]
         aa += a[i]
     return cmoordyn.ext_wave_set(instance, uu, aa, t)
+
+
+def SetWaveKin(instance, u, a, t):
+    """Just an alias for moordyn.ExternalWaveKinSet()
+
+    Parameters:
+    instance (cmoordyn.MoorDyn): The MoorDyn instance
+    u (list (n, 3)): The list of velocities evaluated in the points provided
+                     by moordyn.GetWaveKinCoordinates()
+    a (list (n, 3)): The list of accelerations evaluated in the points provided
+                     by moordyn.GetWaveKinCoordinates()
+    t (float): The simulation time
+
+    Returns:
+    int: 0 uppon success, an error code otherwise
+    """
+    return ExternalWaveKinSet(instance, uu, aa, t)
 
 
 def GetNumberBodies(instance):
@@ -496,6 +525,87 @@ def GetFASTtens(instance, n_lines):
     import cmoordyn
     data = cmoordyn.get_fast_tens(instance, n_lines)
     return data[0], data[1], data[2], data[3]
+
+
+def GetDt(instance):
+    """Get the current model time step
+
+    Parameters:
+    instance (cmoordyn.MoorDyn): The MoorDyn instance
+
+    Returns:
+    dt (float): The time step
+    """
+    import cmoordyn
+    cmoordyn.get_dt(instance)
+
+
+def SetDt(instance, dt):
+    """Set the model time step
+
+    Parameters:
+    instance (cmoordyn.MoorDyn): The MoorDyn instance
+    dt (float): The new time step
+
+    Returns:
+    None
+    """
+    import cmoordyn
+    cmoordyn.set_dt(instance, dt)
+
+
+def GetCFL(instance):
+    """Get the current model Courant–Friedrichs–Lewy factor
+
+    Parameters:
+    instance (cmoordyn.MoorDyn): The MoorDyn instance
+
+    Returns:
+    cfl (float): The Courant–Friedrichs–Lewy factor
+    """
+    import cmoordyn
+    cmoordyn.get_cfl(instance)
+
+
+def SetCFL(instance, cfl):
+    """Set the model Courant–Friedrichs–Lewy factor
+
+    Parameters:
+    instance (cmoordyn.MoorDyn): The MoorDyn instance
+    cfl (float): The new Courant–Friedrichs–Lewy factor
+
+    Returns:
+    None
+    """
+    import cmoordyn
+    cmoordyn.set_cfl(instance, cfl)
+
+
+def GetTimeScheme(instance):
+    """Get the current time scheme name
+
+    Parameters:
+    instance (cmoordyn.MoorDyn): The MoorDyn instance
+
+    Returns:
+    name (str): The time scheme name
+    """
+    import cmoordyn
+    cmoordyn.get_tscheme(instance)
+
+
+def SetTimeScheme(instance, name):
+    """Set the time scheme by its name
+
+    Parameters:
+    instance (cmoordyn.MoorDyn): The MoorDyn instance
+    name (str): The new time scheme name
+
+    Returns:
+    None
+    """
+    import cmoordyn
+    cmoordyn.set_tscheme(instance, name)
 
 
 def SaveState(instance, filepath):

--- a/wrappers/python/moordyn/moordyn.py
+++ b/wrappers/python/moordyn/moordyn.py
@@ -1004,6 +1004,18 @@ def GetRodN(instance):
     return cmoordyn.rod_get_n(instance)
 
 
+def GetRodNumberNodes(instance):
+    """ Get the rod number of nodes
+
+    Parameters:
+    instance (cmoordyn.MoorDynRod): The rod instance
+
+    Returns:
+    n: The number of nodes
+    """
+    return GetRodN(instance) + 1
+
+
 def GetRodNodePos(instance, i):
     """ Get a rod node position
 
@@ -1196,6 +1208,18 @@ def GetLineN(instance):
     """
     import cmoordyn
     return cmoordyn.line_get_n(instance)
+
+
+def GetLineNumberNodes(instance):
+    """ Get the line number of nodes
+
+    Parameters:
+    instance (cmoordyn.MoorDynLine): The line instance
+
+    Returns:
+    n: The number of nodes
+    """
+    return GetLineN(instance) + 1
 
 
 def GetLineUnstretchedLength(instance):


### PR DESCRIPTION
Just a couple of API entries that were missing on the wrappers. Notes:

 - I compiled Python and Fortran. Can anybody try to compile the matlab one?
 - I did not check any of them (related: https://github.com/FloatingArrayDesign/MoorDyn/issues/203)