### PR TITLE
MATLAB wrapper testing

### DIFF
--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -1,13 +1,16 @@
 name: Test MATLAB MEX
 
 on:
-    branches: [ $default-branch, master, wrappers_test ]
+  push:
+    branches: [ $default-branch, master ]
   pull_request:
     branches:
       - "**"
 
 env:
   BUILD_TYPE: Release
+  LD_LIBRARY_PATH: ${{github.workspace}}/install/lib:${{github.workspace}}/install/lib64
+  DYLD_LIBRARY_PATH: ${{github.workspace}}/install/lib
 
 jobs:
   test:
@@ -17,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         # MATLAB requires an old version of Windows
-        os: [ubuntu-latest, macos-latest, windows-2019]
+        os: [ubuntu-latest, macos-latest]
 
     steps:
       - name: Check out repository
@@ -48,9 +51,8 @@ jobs:
               cd('wrappers/matlab/');
               fnames = struct2table(dir('*.cpp')).name;
               for i = 1:length(fnames)
-                  fname = fnames(i)
-                  fprintf('Compiling %s...\n', fname)
-                  mex('-v', fname);
+                  fname = cell2mat(fnames(i));
+                  mex('-v', fname, '-I./', '-I${{github.workspace}}/install/include/moordyn', '-L${{github.workspace}}/install/lib', '-L${{github.workspace}}/install/lib64', '-lmoordyn');
               end
               % Run the same minimal test we have on matlab_bindings.m.in
               system = MoorDynM_Create('../../tests/Mooring/lines.txt');

--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -1,0 +1,90 @@
+name: Test MATLAB MEX
+
+on:
+    branches: [ $default-branch, master, wrappers_test ]
+  pull_request:
+    branches:
+      - "**"
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  test:
+    name: Test MATLAB MEX
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # MATLAB requires an old version of Windows
+        os: [ubuntu-latest, macos-latest, windows-2019]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Create install folder
+        run: |
+            mkdir -p ${{github.workspace}}/install
+
+      - name: Configure CMake (Linux)
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/install -DEXTERNAL_EIGEN:BOOL=OFF -DPYTHON_WRAPPER:BOOL=OFF -DFORTRAN_WRAPPER:BOOL=OFF -DRUST_WRAPPER:BOOL=OFF -DMATLAB_WRAPPER:BOOL=OFF -DUSE_VTK=OFF -DBUILD_TESTING=OFF
+
+      - name: Build
+        id: build
+        run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+      - name: Install
+        run: cmake --install ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+      - name: Set up MATLAB
+        uses: matlab-actions/setup-matlab@v2
+
+      - name: Compile and run
+        uses: matlab-actions/run-command@v2
+        with:
+          command: |
+              mex('-setup', '-v', 'C');
+              cd('wrappers/matlab/');
+              fnames = struct2table(dir('*.cpp')).name;
+              for i = 1:length(fnames)
+                  fname = fnames(i)
+                  fprintf('Compiling %s...\n', fname)
+                  mex('-v', fname);
+              end
+              % Run the same minimal test we have on matlab_bindings.m.in
+              system = MoorDynM_Create('../../tests/Mooring/lines.txt');
+              %% 3 coupled points x 3 components per point = 9 DoF
+              x = zeros(9,1);
+              dx = zeros(9,1);
+              %% Get the initial positions from the system itself
+              for i=1:3
+                %% 4 = first fairlead id
+                point = MoorDynM_GetPoint(system, i + 3);
+                x(1 + 3 * (i - 1):3 * i) = MoorDynM_GetPointPos(point);
+              end
+              %% Setup the initial condition
+              MoorDynM_Init(system, x, dx);
+              %% Make the points move at 0.5 m/s to the positive x direction
+              for i=1:3
+                dx(1 + 3 * (i - 1)) = 0.5;
+              end
+              t = 0.0;
+              dt = 0.5;
+              [t, f] = MoorDynM_Step(system, x, dx, t, dt);
+              %% Print the position and tension of the line nodes
+              n_lines = MoorDynM_GetNumberLines(system);
+              for line_id=1:n_lines
+                line_id
+                line = MoorDynM_GetLine(system, line_id);
+                n_nodes = MoorDynM_GetLineNumberNodes(line);
+                for node_id=1:n_nodes
+                  node_id
+                  pos = MoorDynM_GetLineNodePos(line, node_id - 1);
+                  pos
+                  ten = MoorDynM_GetLineNodeTen(line, node_id - 1);
+                  ten
+                end
+              end
+              %% Alright, time to finish!
+              MoorDynM_Close(system);


### PR DESCRIPTION
A GitHUB action to compile the MATLAB mex files and run a small test. Notes:

- It is quite shitty because it can not be integrated with CMake
- I tried to make it work on Windows, but it gives an error with little to none useful information to fix it.
- At some point it would be great to have a common framework to create and run the tests with both GitHUB actions and CMake