### PR TITLE
fix: added dummy AllOutput to old API

### DIFF
--- a/source/MoorDyn.cpp
+++ b/source/MoorDyn.cpp
@@ -287,5 +287,5 @@ AllOutput(double t, double dt)
 {
 	if (!md_singleton)
 		return;
-	std::cout << "In version 2, AllOutput is automatically called by MoorDynStep" << std::endl;
+	std::cout << "In version 2, AllOutput is automatically called by MoorDynInit and MoorDynStep" << std::endl;
 }

--- a/source/MoorDyn.cpp
+++ b/source/MoorDyn.cpp
@@ -287,5 +287,5 @@ AllOutput(double t, double dt)
 {
 	if (!md_singleton)
 		return;
-	std::cout << "In version 2, AllOutput is automatically called by MoorDynInit and MoorDynStep" << std::endl;
+	MoorDyn_Log(md_singleton, MOORDYN_MSG_LEVEL, "In version 2, AllOutput is automatically called by MoorDynInit and MoorDynStep");
 }

--- a/source/MoorDyn.cpp
+++ b/source/MoorDyn.cpp
@@ -281,3 +281,11 @@ GetNodePos(int LineNum, int NodeNum, double pos[3])
 	auto line = MoorDyn_GetLine(md_singleton, LineNum);
 	return MoorDyn_GetLineNodePos(line, NodeNum, pos);
 }
+
+int DECLDIR
+AllOutput(double t, double dt)
+{
+	if (!md_singleton)
+		return MOORDYN_MEM_ERROR;
+	std::cout << "In version 2, AllOutput is automatically called by MoorDynStep" << std::endl;
+}

--- a/source/MoorDyn.cpp
+++ b/source/MoorDyn.cpp
@@ -282,10 +282,10 @@ GetNodePos(int LineNum, int NodeNum, double pos[3])
 	return MoorDyn_GetLineNodePos(line, NodeNum, pos);
 }
 
-int DECLDIR
+void DECLDIR
 AllOutput(double t, double dt)
 {
 	if (!md_singleton)
-		return MOORDYN_MEM_ERROR;
+		return;
 	std::cout << "In version 2, AllOutput is automatically called by MoorDynStep" << std::endl;
 }

--- a/source/MoorDyn.h
+++ b/source/MoorDyn.h
@@ -142,7 +142,7 @@ extern "C"
 	int DECLDIR GetPointForce(int l, double force[3]);
 	int DECLDIR GetNodePos(int LineNum, int NodeNum, double pos[3]);
 
-	void AllOutput(double, double);
+	void DECLDIR AllOutput(double, double);
 
 	/**
 	 * @}

--- a/source/MoorDyn.h
+++ b/source/MoorDyn.h
@@ -142,7 +142,7 @@ extern "C"
 	int DECLDIR GetPointForce(int l, double force[3]);
 	int DECLDIR GetNodePos(int LineNum, int NodeNum, double pos[3]);
 
-	int AllOutput(double, double);
+	void AllOutput(double, double);
 
 	/**
 	 * @}

--- a/source/MoorDyn2.cpp
+++ b/source/MoorDyn2.cpp
@@ -624,7 +624,7 @@ moordyn::MoorDyn::Init(const double* x, const double* xd, bool skip_ic)
 	}
 
 	// write t=0 output
-	return AllOutput(0.0, 0.0);
+	return WriteOutputs(0.0, 0.0);
 }
 
 moordyn::error_id DECLDIR
@@ -761,7 +761,7 @@ moordyn::MoorDyn::Step(const double* x,
 	// specifying max tension things)
 
 	// ------------------------ write outputs --------------------------
-	const moordyn::error_id err = AllOutput(t, dt);
+	const moordyn::error_id err = WriteOutputs(t, dt);
 	if (err != MOORDYN_SUCCESS)
 		return err;
 
@@ -2325,7 +2325,7 @@ moordyn::MoorDyn::detachLines(FailProps* failure)
 }
 
 moordyn::error_id
-moordyn::MoorDyn::AllOutput(double t, double dt)
+moordyn::MoorDyn::WriteOutputs(double t, double dt)
 {
 	if (disableOutput)
 		return MOORDYN_SUCCESS;

--- a/source/MoorDyn2.hpp
+++ b/source/MoorDyn2.hpp
@@ -847,7 +847,7 @@ class MoorDyn final : public io::IO
 	 * @return MOORDYN_SUCCESS if the output is correctly printed, an error
 	 * code otherwise
 	 */
-	moordyn::error_id AllOutput(double t, double dt);
+	moordyn::error_id WriteOutputs(double t, double dt);
 };
 
 } // ::moordyn


### PR DESCRIPTION
This adds a dummy AllOutput function to the old API wrapper that prints a message stating "In version 2, AllOutput is automatically called by MoorDynStep". This reduces warning messages when using the old API. This was seen when updating the WECSim libraries in https://github.com/WEC-Sim/MoorDyn/pull/7. 

@sanguinariojoe, let me know if there is a better way to print the message here. I didn't see anything in the C header files that allowed for the use of LOGMSG.