### PR TITLE
Temporal fix for the CI/CD

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -71,7 +71,7 @@ jobs:
     needs: [create_release]
     strategy:
         matrix:
-            os: [ubuntu-22.04, windows-latest, macOS-latest]
+            os: [ubuntu-22.04, windows-2022]
 
     steps:
     - uses: actions/checkout@v5


### PR DESCRIPTION
I removed MacOS (arm64) and downgraded Windows to 2022 (the latest version where NSIS is still available)