### PR TITLE
fixed(examples): Removed the tbd field from the Bodies & rods example

### DIFF
--- a/tests/Mooring/BodiesAndRods.dat
+++ b/tests/Mooring/BodiesAndRods.dat
@@ -1,18 +1,18 @@
 MoorDyn v2 input file for RM3 WEC - added in a cable too
 ------------------------- LINE TYPES --------------------------------------------------
-LineType  Diam    MassDenInAir    EA       BA/-zeta    EI    tbd   Can   Cat  Cdn   Cdt 
-(-)       (m)       (kg/m)        (N)      (Pa-s/-)  (n-m^2) (-)   (-)   (-)  (-)   (-)  
-nylon      0.124      13.76    2515288.0     -0.8      0.0   0.0   1.0   0.0  1.6   0.05
-cable     0.175      40       751e6       -0.8      0         1.0     0.0    1.2     0.008    
-buoyancy  0.26       40       751e6       -0.8      0         1.0     0.0    1.2     0.008 
+LineType  Diam    MassDenInAir    EA       BA/-zeta    EI    Can   Cat  Cdn   Cdt
+(-)       (m)       (kg/m)        (N)      (Pa-s/-)  (n-m^2) (-)   (-)  (-)   (-)
+nylon     0.124      13.76    2515288.0     -0.8      0.0    1.0   0.0  1.6   0.05
+cable     0.175      40       751e6         -0.8      0.0    1.0   0.0  1.2   0.008
+buoyancy  0.26       40       751e6         -0.8      0.0    1.0   0.0  1.2   0.008
 ---------------------- ROD TYPES ------------------------------------
 TypeName      Diam     Mass/m    Cd     Ca      CdEnd    CaEnd
 (name)        (m)      (kg/m)    (-)    (-)     (-)      (-)
-Can          10       1.0e3     0.6    1.0     1.2      1.0
+Can           10       1.0e3     0.6    1.0     1.2      1.0
 ---------------------------- BODIES -----------------------------------------------------
 ID   Attachment  X0     Y0    Z0     r0      p0     y0     Mass  CG*   I*      Volume   CdA*   Ca
 (#)     (-)      (m)    (m)   (m)   (deg)   (deg)  (deg)   (kg)  (m)  (kg-m^2)  (m^3)   (m^2)  (-)
-1       free      0     0      0     0       0      0      1e6     0    1e10        0       0      0
+1       free      0     0      0     0       0      0      1e6    0    1e10      0       0      0
 ---------------------- RODS ----------------------------------------
 ID   RodType  Attachment  Xa    Ya    Za    Xb    Yb    Zb   NumSegs  RodOutputs
 (#)  (name)    (#/key)    (m)   (m)   (m)   (m)   (m)   (m)  (-)       (-)
@@ -21,25 +21,25 @@ ID   RodType  Attachment  Xa    Ya    Za    Xb    Yb    Zb   NumSegs  RodOutputs
 ----------------------- POINTS ----------------------------------------------
 Node      Type      X        Y         Z        M        V         CdA   CA
 (-)       (-)      (m)      (m)       (m)      (kg)     (m^3)     (m^2)  (-)
-1         Body1      0.0     0      -10.00       0        0          0     0
-2         Fixed    267.0     0      -70.00       0        0          0     0
-3         Body1      0.0     0      -10.00       0        0          0     0
-4         Fixed   -133.5   231.23   -70.00       0        0          0     0
-5         Body1      0.0     0      -10.00       0        0          0     0
-6         Fixed   -133.5  -231.23   -70.00       0        0          0     0
-7        Fixed    -200      0      -70        0       0       0    0
-8        Free      -60      0      -30        0       0       0    0
-9        Free      -20      0      -30        0       0       0    0
-10       Body1       0      0        0        0       0       0    0
+1         Body1      0.0     0      -10.00      0        0         0     0
+2         Fixed    267.0     0      -70.00      0        0         0     0
+3         Body1      0.0     0      -10.00      0        0         0     0
+4         Fixed   -133.5   231.23   -70.00      0        0         0     0
+5         Body1      0.0     0      -10.00      0        0         0     0
+6         Fixed   -133.5  -231.23   -70.00      0        0         0     0
+7         Fixed   -200       0      -70         0        0         0     0
+8         Free     -60       0      -30         0        0         0     0
+9         Free     -20       0      -30         0        0         0     0
+10        Body1       0      0        0         0        0         0     0
 -------------------------- LINES -------------------------------------------------
 Line     LineType NodeA     NodeB  UnstrLen  NumSegs     Flags/Outputs
 (-)      (-)       (-)       (-)   (m)         (-)          (-)
 1        nylon      2         1    300.0        50           p
 2        nylon      4         3    300.0        50           p
 3        nylon      6         5    300.0        50           p
-4        cable      7          8      200         12        p
-5      buoyancy     8          9       50          6        p
-6        cable      9         10       50          6        p
+4        cable      7         8    200          12           p
+5      buoyancy     8         9     50           6           p
+6        cable      9        10     50           6           p
 -------------------------- SOLVER OPTIONS---------------------------------------------------
 2        writeLog     - Write a log file
 0.0005   dtM          - time step to use in mooring integration


### PR DESCRIPTION
Fixes #348 