### PR TITLE
fix(core): Memory leak on lean-vtk

### DIFF
--- a/source/leanvtk/leanvtk.hpp
+++ b/source/leanvtk/leanvtk.hpp
@@ -141,6 +141,8 @@ public:
       , binary_(false)
   {}
 
+  virtual ~VTKDataNodeBase() = default;
+
   virtual void write(std::ostream &os) const
   {
   };


### PR DESCRIPTION
Just a small defect that causes some memory leaks. See https://github.com/mmorse1217/lean-vtk/pull/13