### PR TITLE
fix(core): Return an error code when points below the seabed are detected

### DIFF
--- a/source/MoorDyn2.cpp
+++ b/source/MoorDyn2.cpp
@@ -522,7 +522,12 @@ moordyn::MoorDyn::Init(const double* x, const double* xd, bool skip_ic)
 		}
 		// call this just to set WaterKin (may also set up output file in
 		// future)
-		PointList[l]->initialize();
+		try {
+			PointList[l]->initialize();
+		}
+		MOORDYN_CATCHER(err, err_msg);
+		if (err != MOORDYN_SUCCESS)
+			return err;
 		ix += 3;
 	}
 


### PR DESCRIPTION
When a point falls below the seabed, Point.cpp:152 raises an exception, which is not catched, letting the full code to crash