### PR TITLE
Patch the points below seabed errors and #384

### DIFF
--- a/source/MoorDyn2.cpp
+++ b/source/MoorDyn2.cpp
@@ -522,12 +522,7 @@ moordyn::MoorDyn::Init(const double* x, const double* xd, bool skip_ic)
 		}
 		// call this just to set WaterKin (may also set up output file in
 		// future)
-		try {
-			PointList[l]->initialize();
-		}
-		MOORDYN_CATCHER(err, err_msg);
-		if (err != MOORDYN_SUCCESS)
-			return err;
+		PointList[l]->initialize();
 		ix += 3;
 	}
 
@@ -1193,9 +1188,10 @@ moordyn::MoorDyn::ReadInFile()
 			// Note - this is not in MD-F
 			if (r0[2] < -env->WtrDpth) {
 				env->WtrDpth = -r0[2];
-				LOGWRN << "\t Water depth set to point " << PointList.size() + 1
-				       << " z position because point was specified below the "
-				          "seabed" << endl;
+				LOGWRN << "\t Water depth set to point "
+				       << PointList.size() + 1
+				       << " z position because point was specified below the"
+				       << " seabed" << endl;
 			}
 
 			// Check point ID is sequential starting from 1

--- a/source/Point.cpp
+++ b/source/Point.cpp
@@ -173,11 +173,10 @@ Point::initialize()
 		const real waterDepth =
 		    seafloor ? seafloor->getDepthAt(r[0], r[1]) : -env->WtrDpth;
 		if (waterDepth > r[2]) {
-			LOGERR << "Error: water depth is shallower than Point " << number
+			LOGWRN << "Error: water depth is shallower than Point " << number
 			       << "." << endl
 			       << "\tseabed z = " << waterDepth << endl
 			       << "\tpoint = " << r << endl;
-			throw moordyn::invalid_value_error("Invalid water depth");
 		}
 	}
 

--- a/wrappers/matlab/MoorDynM_Load.cpp
+++ b/wrappers/matlab/MoorDynM_Load.cpp
@@ -39,7 +39,7 @@ using matlab::mex::ArgumentList;
 
 MOORDYNM_MEX_FUNCTION_BEGIN(MoorDyn, 2, 0)
 {
-	const CharArray filename_matlab = inputs[0];
+	const CharArray filename_matlab = inputs[1];
 	std::string filename(filename_matlab.toAscii());
 	const int err = MoorDyn_Load(instance, filename.c_str());
 	MOORDYNM_CHECK_ERROR(err);

--- a/wrappers/matlab/MoorDynM_LoadState.cpp
+++ b/wrappers/matlab/MoorDynM_LoadState.cpp
@@ -39,7 +39,7 @@ using matlab::mex::ArgumentList;
 
 MOORDYNM_MEX_FUNCTION_BEGIN(MoorDyn, 2, 0)
 {
-	const CharArray filename_matlab = inputs[0];
+	const CharArray filename_matlab = inputs[1];
 	std::string filename(filename_matlab.toAscii());
 	const int err = MoorDyn_LoadState(instance, filename.c_str());
 	MOORDYNM_CHECK_ERROR(err);

--- a/wrappers/matlab/MoorDynM_Save.cpp
+++ b/wrappers/matlab/MoorDynM_Save.cpp
@@ -39,7 +39,7 @@ using matlab::mex::ArgumentList;
 
 MOORDYNM_MEX_FUNCTION_BEGIN(MoorDyn, 2, 0)
 {
-	const CharArray filename_matlab = inputs[0];
+	const CharArray filename_matlab = inputs[1];
 	std::string filename(filename_matlab.toAscii());
 	const int err = MoorDyn_Save(instance, filename.c_str());
 	MOORDYNM_CHECK_ERROR(err);

--- a/wrappers/matlab/MoorDynM_SaveBodyVTK.cpp
+++ b/wrappers/matlab/MoorDynM_SaveBodyVTK.cpp
@@ -39,7 +39,7 @@ using matlab::mex::ArgumentList;
 
 MOORDYNM_MEX_FUNCTION_BEGIN(MoorDynBody, 2, 0)
 {
-	const CharArray filename_matlab = inputs[0];
+	const CharArray filename_matlab = inputs[1];
 	std::string filename(filename_matlab.toAscii());
 	const int err = MoorDyn_SaveBodyVTK(instance, filename.c_str());
 	MOORDYNM_CHECK_ERROR(err);

--- a/wrappers/matlab/MoorDynM_SaveLineVTK.cpp
+++ b/wrappers/matlab/MoorDynM_SaveLineVTK.cpp
@@ -39,7 +39,7 @@ using matlab::mex::ArgumentList;
 
 MOORDYNM_MEX_FUNCTION_BEGIN(MoorDynLine, 2, 0)
 {
-	const CharArray filename_matlab = inputs[0];
+	const CharArray filename_matlab = inputs[1];
 	std::string filename(filename_matlab.toAscii());
 	const int err = MoorDyn_SaveLineVTK(instance, filename.c_str());
 	MOORDYNM_CHECK_ERROR(err);

--- a/wrappers/matlab/MoorDynM_SaveRodVTK.cpp
+++ b/wrappers/matlab/MoorDynM_SaveRodVTK.cpp
@@ -39,7 +39,7 @@ using matlab::mex::ArgumentList;
 
 MOORDYNM_MEX_FUNCTION_BEGIN(MoorDynRod, 2, 0)
 {
-	const CharArray filename_matlab = inputs[0];
+	const CharArray filename_matlab = inputs[1];
 	std::string filename(filename_matlab.toAscii());
 	const int err = MoorDyn_SaveRodVTK(instance, filename.c_str());
 	MOORDYNM_CHECK_ERROR(err);

--- a/wrappers/matlab/MoorDynM_SaveState.cpp
+++ b/wrappers/matlab/MoorDynM_SaveState.cpp
@@ -39,7 +39,7 @@ using matlab::mex::ArgumentList;
 
 MOORDYNM_MEX_FUNCTION_BEGIN(MoorDyn, 2, 0)
 {
-	const CharArray filename_matlab = inputs[0];
+	const CharArray filename_matlab = inputs[1];
 	std::string filename(filename_matlab.toAscii());
 	const int err = MoorDyn_SaveState(instance, filename.c_str());
 	MOORDYNM_CHECK_ERROR(err);

--- a/wrappers/matlab/MoorDynM_SaveVTK.cpp
+++ b/wrappers/matlab/MoorDynM_SaveVTK.cpp
@@ -39,7 +39,7 @@ using matlab::mex::ArgumentList;
 
 MOORDYNM_MEX_FUNCTION_BEGIN(MoorDyn, 2, 0)
 {
-	const CharArray filename_matlab = inputs[0];
+	const CharArray filename_matlab = inputs[1];
 	std::string filename(filename_matlab.toAscii());
 	const int err = MoorDyn_SaveVTK(instance, filename.c_str());
 	MOORDYNM_CHECK_ERROR(err);

--- a/wrappers/matlab/MoorDynM_SetLogFile.cpp
+++ b/wrappers/matlab/MoorDynM_SetLogFile.cpp
@@ -39,7 +39,7 @@ using matlab::mex::ArgumentList;
 
 MOORDYNM_MEX_FUNCTION_BEGIN(MoorDyn, 2, 0)
 {
-	const CharArray filename_matlab = inputs[0];
+	const CharArray filename_matlab = inputs[1];
 	std::string filename(filename_matlab.toAscii());
 	const int err = MoorDyn_SetLogFile(instance, filename.c_str());
 	MOORDYNM_CHECK_ERROR(err);

--- a/wrappers/matlab/MoorDynM_SetTimeScheme.cpp
+++ b/wrappers/matlab/MoorDynM_SetTimeScheme.cpp
@@ -39,7 +39,7 @@ using matlab::mex::ArgumentList;
 
 MOORDYNM_MEX_FUNCTION_BEGIN(MoorDyn, 2, 0)
 {
-	const CharArray name_matlab = inputs[0];
+	const CharArray name_matlab = inputs[1];
 	std::string name(name_matlab.toAscii());
 	const int err = MoorDyn_SetTimeScheme(instance, name.c_str());
 	MOORDYNM_CHECK_ERROR(err);


### PR DESCRIPTION
Regarding #384, not much else to say, it was just a bug.

Regarding the points below seabed, the rationale was wrong. First, a check on the position set on the config file is already done during the configuration read stage:

https://github.com/FloatingArrayDesign/MoorDyn/blob/master/source/MoorDyn2.cpp#L1154

And that stage just a warning is triggered. On top of that, it might be the case that someone would call `MoorDyn_Init()` on an already initialized system. However, if the line was slack, then inner points most probably fall slightly below the seabed (as long as the seabed is a spring).

Thus I am just demoting the error to a warning (without throwing an exception)